### PR TITLE
Fix crash caused by recreating static nested classes using reflection

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
@@ -928,7 +928,7 @@ public abstract class Controller {
         }
 
         Bundle outState = new Bundle();
-        outState.putString(KEY_CLASS_NAME, getClass().getCanonicalName());
+        outState.putString(KEY_CLASS_NAME, getClass().getName());
         outState.putBundle(KEY_VIEW_STATE, mViewState);
         outState.putBundle(KEY_ARGS, mArgs);
         outState.putString(KEY_INSTANCE_ID, mInstanceId);

--- a/conductor/src/main/java/com/bluelinelabs/conductor/ControllerChangeHandler.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/ControllerChangeHandler.java
@@ -53,7 +53,7 @@ public abstract class ControllerChangeHandler {
 
     final Bundle toBundle() {
         Bundle bundle = new Bundle();
-        bundle.putString(KEY_CLASS_NAME, getClass().getCanonicalName());
+        bundle.putString(KEY_CLASS_NAME, getClass().getName());
 
         Bundle savedState = new Bundle();
         saveToBundle(savedState);

--- a/conductor/src/main/java/com/bluelinelabs/conductor/changehandler/TransitionChangeHandlerCompat.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/changehandler/TransitionChangeHandlerCompat.java
@@ -50,8 +50,8 @@ public class TransitionChangeHandlerCompat extends ControllerChangeHandler {
     public void saveToBundle(@NonNull Bundle bundle) {
         super.saveToBundle(bundle);
 
-        bundle.putString(KEY_TRANSITION_HANDLER_CLASS, mTransitionChangeHandler.getClass().getCanonicalName());
-        bundle.putString(KEY_FALLBACK_HANDLER_CLASS, mFallbackChangeHandler.getClass().getCanonicalName());
+        bundle.putString(KEY_TRANSITION_HANDLER_CLASS, mTransitionChangeHandler.getClass().getName());
+        bundle.putString(KEY_FALLBACK_HANDLER_CLASS, mFallbackChangeHandler.getClass().getName());
 
         Bundle transitionBundle = new Bundle();
         mTransitionChangeHandler.saveToBundle(transitionBundle);


### PR DESCRIPTION
> Caused by: java.lang.RuntimeException: An exception occurred while creating a new instance of de.myapp.ui.user.UserInfoActivity.MyChangeHandler. An exception occurred while finding class for name de.myapp.ui.user.UserInfoActivity.MyChangeHandler. de.myapp.ui.user.UserInfoActivity.MyChangeHandler

The same error also occurs with Controllers
Relevant [SO](http://stackoverflow.com/questions/15202997/what-is-the-difference-between-canonical-name-simple-name-and-class-name-in-jav) post
