### PR TITLE
Automatically deploy snapshot from tavis

### DIFF
--- a/.buildscript/deploy_snapshot.sh
+++ b/.buildscript/deploy_snapshot.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Deploy a jar, source jar, and javadoc jar to Sonatype's snapshot repo.
+#
+# Adapted from https://coderwall.com/p/9b_lfq and
+# http://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
+
+SLUG="bluelinelabs/Conductor"
+JDK="oraclejdk8"
+BRANCH="develop"
+
+set -e
+
+if [ "$TRAVIS_REPO_SLUG" != "$SLUG" ]; then
+  echo "Skipping snapshot deployment: wrong repository. Expected '$SLUG' but was '$TRAVIS_REPO_SLUG'."
+elif [ "$TRAVIS_JDK_VERSION" != "$JDK" ]; then
+  echo "Skipping snapshot deployment: wrong JDK. Expected '$JDK' but was '$TRAVIS_JDK_VERSION'."
+elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  echo "Skipping snapshot deployment: was pull request."
+elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
+  echo "Skipping snapshot deployment: wrong branch. Expected '$BRANCH' but was '$TRAVIS_BRANCH'."
+else
+  echo "Deploying snapshot..."
+  ./gradlew clean uploadArchives
+  echo "Snapshot deployed!"
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,20 @@ android:
 
 script:
   - ./gradlew test
+
+jdk:
+  - oraclejdk8
+
+after_success:
+  - .buildscript/deploy_snapshot.sh
+
+cache:
+  directories:
+    - $HOME/.gradle
+
+sudo: false
+
+env:
+  global:
+    - secure TODO: BINTRAY_USER
+    - secure TODO: BINTRAY_API_KEY


### PR DESCRIPTION
As you might have already noticed you are releasing quite often minor changes and bugfixes like #17 #20 etc.

This is not a bad thing!

But I would like to discuss, if it would make more sense to deploy snapshots to give those users that are really in need of the merged changes like #17 fast, but also gives you the ability to be a little bit slower regarding versioning and releasing. What I mean is, instead of publishing a new version every 2-3 days, publish a snapshot after each commit / pull request, and after having applied two or three changes publish a new version.

So in this pull request, I want to purpose to use travis ci to automatically publish SNAPSHOTS.


**Please don't merge this pull request for now**. There are some things that we have to discuss as I haven't used bintray before and probably I have to adjust some files and you also have to fill in some things like bintray credentials.

What do you think about deploying SNAPSHOTS automatically? 