### PR TITLE
added methods to lifecyclelistener for saving/restoring viewstate

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
@@ -1084,7 +1084,7 @@ public abstract class Controller {
         public void onRestoreInstanceState(@NonNull Controller controller, @NonNull Bundle savedInstanceState) { }
 
         public void onSaveViewState(@NonNull Controller controller, @NonNull Bundle outState) { }
-        public void onRestoreViewState(@NonNull Controller controller, @NonNull Bundle savedInstanceState) { }
+        public void onRestoreViewState(@NonNull Controller controller, @NonNull Bundle savedViewState) { }
     }
 
 }

--- a/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
@@ -907,6 +907,10 @@ public abstract class Controller {
                 child.controller.saveViewState(child.controller.mView);
             }
         }
+
+        for (LifecycleListener lifecycleListener : mLifecycleListeners) {
+            lifecycleListener.onSaveViewState(this, mViewState);
+        }
     }
 
     final void restoreViewState(@NonNull View view) {
@@ -918,6 +922,10 @@ public abstract class Controller {
                 if (child.controller.mView != null) {
                     child.controller.restoreViewState(child.controller.mView);
                 }
+            }
+
+            for (LifecycleListener lifecycleListener : mLifecycleListeners) {
+                lifecycleListener.onRestoreViewState(this, mViewState);
             }
         }
     }
@@ -1074,6 +1082,9 @@ public abstract class Controller {
 
         public void onSaveInstanceState(@NonNull Controller controller, @NonNull Bundle outState) { }
         public void onRestoreInstanceState(@NonNull Controller controller, @NonNull Bundle savedInstanceState) { }
+
+        public void onSaveViewState(@NonNull Controller controller, @NonNull Bundle outState) { }
+        public void onRestoreViewState(@NonNull Controller controller, @NonNull Bundle savedInstanceState) { }
     }
 
 }


### PR DESCRIPTION
It would be nice to have lifecycle listeners for `onSaveViewState()` and `onRestoreViewState()`. Would make life easier for other third party plugins like Mosby.

Wanted to at tests for that, but haven't found tests for `onSaveInstanceState()` and `onRestoreInstanceState()` where I could add my tests for `onSaveViewState()` and `onRestoreViewState()`. Have I missed something?

Have I picked the right bundle for the view state?