### PR TITLE
Make getControllerWithInstanceId search recursively

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
@@ -271,17 +271,17 @@ public abstract class Controller {
     }
 
     /**
-     * Returns the a nested Controller with the given instance id, if available.
-     *
+     * Returns the Controller with the given instance id, if available.
+     * May return the controller itself or a matching descendant
      * @param instanceId The instance ID being searched for
      * @return The matching Controller, if one exists
      */
-    public final Controller getControllerWithInstanceId(String instanceId) {
-        if (getInstanceId().equals(instanceId))
+    final Controller findController(String instanceId) {
+        if (mInstanceId.equals(instanceId))
             return this;
 
         for (ControllerTransaction transaction : mChildControllers) {
-            Controller controllerWithId = transaction.controller.getControllerWithInstanceId(instanceId);
+            Controller controllerWithId = transaction.controller.findController(instanceId);
             if (controllerWithId != null)
                 return controllerWithId;
         }

--- a/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
@@ -270,6 +270,24 @@ public abstract class Controller {
     }
 
     /**
+     * Returns the a nested Controller with the given instance id, if available.
+     *
+     * @param instanceId The instance ID being searched for
+     * @return The matching Controller, if one exists
+     */
+    public final Controller getControllerWithInstanceId(String instanceId) {
+        if (getInstanceId().equals(instanceId))
+            return this;
+
+        for (ControllerTransaction transaction : mChildControllers) {
+            Controller controllerWithId = transaction.controller.getControllerWithInstanceId(instanceId);
+            if (controllerWithId != null)
+                return controllerWithId;
+        }
+        return null;
+    }
+
+    /**
      * Returns all of this Controller's child Controllers
      */
     public final List<Controller> getChildControllers() {

--- a/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
@@ -256,10 +256,11 @@ public abstract class Controller {
 
     /**
      * Returns the child Controller with the given instance id, if available.
-     *
      * @param instanceId The instance ID being searched for
      * @return The matching child Controller, if one exists
+     * @deprecated Use {@link #getChildController(String)} or {@link #getChildControllers()} instead.
      */
+    @Deprecated
     public final Controller getChildControllerWithInstanceId(String instanceId) {
         for (ControllerTransaction transaction : mChildControllers) {
             if (transaction.controller.getInstanceId().equals(instanceId)) {

--- a/conductor/src/main/java/com/bluelinelabs/conductor/Router.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Router.java
@@ -271,14 +271,10 @@ public class Router {
      */
     public Controller getControllerWithInstanceId(String instanceId) {
         for (ControllerTransaction transaction : mBackStack) {
-            if (transaction.controller.getInstanceId().equals(instanceId)) {
-                return transaction.controller;
-            } else {
-                Controller childWithId = transaction.controller.getChildControllerWithInstanceId(instanceId);
-                if (childWithId != null) {
-                    return childWithId;
+            Controller controllerWithId = transaction.controller.getControllerWithInstanceId(instanceId);
+                if (controllerWithId != null) {
+                    return controllerWithId;
                 }
-            }
         }
         return null;
     }

--- a/conductor/src/main/java/com/bluelinelabs/conductor/Router.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Router.java
@@ -271,7 +271,7 @@ public class Router {
      */
     public Controller getControllerWithInstanceId(String instanceId) {
         for (ControllerTransaction transaction : mBackStack) {
-            Controller controllerWithId = transaction.controller.getControllerWithInstanceId(instanceId);
+            Controller controllerWithId = transaction.controller.findController(instanceId);
                 if (controllerWithId != null) {
                     return controllerWithId;
                 }


### PR DESCRIPTION
This PR adds a new public method to Controller `getControllerWithInstanceId(instanceId)` for searching for a controller recursively. This returns the controller itself, or any of its descendants (children).

This will fix #29 

This is currently an addition to the public api.
Should I alter this PR to do any of the following ?

- remove `getChildControllerWithInstanceId(instanceId)` 
- deprecate `getChildControllerWithInstanceId(instanceId)` 
- make `getChildControllerWithInstanceId(instanceId)`  search recursively and keep the existing api
- make the new method internal 