### PR TITLE
Add proguard rules

### DIFF
--- a/conductor/build.gradle
+++ b/conductor/build.gradle
@@ -28,6 +28,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode Integer.parseInt(project.VERSION_CODE)
         versionName project.VERSION_NAME
+        consumerProguardFiles 'proguard-rules.txt'
     }
 }
 

--- a/conductor/proguard-rules.txt
+++ b/conductor/proguard-rules.txt
@@ -1,0 +1,4 @@
+# Retain constructor that is called by using reflection to recreate the Controller
+-keepclassmembers public class * extends com.bluelinelabs.conductor.Controller {
+   public <init>(android.os.Bundle);
+}

--- a/conductor/proguard-rules.txt
+++ b/conductor/proguard-rules.txt
@@ -1,4 +1,5 @@
 # Retain constructor that is called by using reflection to recreate the Controller
 -keepclassmembers public class * extends com.bluelinelabs.conductor.Controller {
+   public <init>();
    public <init>(android.os.Bundle);
 }


### PR DESCRIPTION
This will add proguard rules into the generated AAR files to keep the Controller constructor that is used via reflection. 
Are there any other places where reflection may break proguard ?