### PR TITLE
Target Controller large bitmap issue fix

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     compile rootProject.ext.supportDesign
 
     compile rootProject.ext.butterknife
+    compile rootProject.ext.picasso
 
     compile project(':conductor-support')
     compile project(':conductor-rxlifecycle')

--- a/demo/src/main/java/com/bluelinelabs/conductor/demo/controllers/TargetDisplayController.java
+++ b/demo/src/main/java/com/bluelinelabs/conductor/demo/controllers/TargetDisplayController.java
@@ -18,6 +18,7 @@ import com.bluelinelabs.conductor.changehandler.HorizontalChangeHandler;
 import com.bluelinelabs.conductor.demo.R;
 import com.bluelinelabs.conductor.demo.controllers.TargetTitleEntryController.TargetTitleEntryControllerListener;
 import com.bluelinelabs.conductor.demo.controllers.base.BaseController;
+import com.squareup.picasso.Picasso;
 
 import butterknife.Bind;
 import butterknife.OnClick;
@@ -100,7 +101,11 @@ public class TargetDisplayController extends BaseController implements TargetTit
     }
 
     private void setImageView() {
-        mImageView.setImageURI(mImageUri);
+        Picasso.with(getActivity())
+                .load(mImageUri)
+                .fit()
+                .centerCrop()
+                .into(mImageView);
     }
 
     private void setTextView() {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,6 +10,7 @@ ext {
     supportAppCompat = 'com.android.support:appcompat-v7:23.1.1'
 
     butterknife = 'com.jakewharton:butterknife:7.0.1'
+    picasso = 'com.squareup.picasso:picasso:2.5.2'
 
     leakCanary = 'com.squareup.leakcanary:leakcanary-android:1.4-beta2'
     leakCanaryNoOp = 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta2'


### PR DESCRIPTION
`ImageView.setImageURI()` doesn't resize Bitmaps, it may lead to a silent error in logs when you try to pick a high resolution image:
`Bitmap too large to be uploaded into a texture (4160x3120, max=4096x4096)`

One approach is to do it manually, the other is to use a third party library. Since Demo uses Butterknife, Picasso would be a consistent choice.