### PR TITLE
Add link to Javadoc from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Travis Build](https://travis-ci.org/bluelinelabs/Conductor.svg)](https://travis-ci.org/bluelinelabs/Conductor) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Conductor-brightgreen.svg?style=flat)](http://android-arsenal.com/details/1/3361)
+[![Travis Build](https://travis-ci.org/bluelinelabs/Conductor.svg)](https://travis-ci.org/bluelinelabs/Conductor) [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Conductor-brightgreen.svg?style=flat)](http://android-arsenal.com/details/1/3361) [![Javadocs](http://javadoc.io/badge/com.bluelinelabs/conductor.svg)](http://javadoc.io/doc/com.bluelinelabs/conductor)
 
 # Conductor
 


### PR DESCRIPTION
I didn't see any link to Javadoc from the readme. This badge links to a service which provides hosted Javadoc auto-generated from artifacts in Maven Central.

More info at http://javadoc.io/