### PR TITLE
Fix VerticalChangeHandler

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/changehandler/VerticalChangeHandler.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/changehandler/VerticalChangeHandler.java
@@ -35,10 +35,20 @@ public class VerticalChangeHandler extends AnimatorChangeHandler {
         AnimatorSet animator = new AnimatorSet();
         List<Animator> viewAnimators = new ArrayList<>();
 
-        if (isPush && to != null) {
-            viewAnimators.add(ObjectAnimator.ofFloat(to, View.TRANSLATION_Y, to.getHeight(), 0));
-        } else if (!isPush && from != null) {
-            viewAnimators.add(ObjectAnimator.ofFloat(from, View.TRANSLATION_Y, from.getHeight()));
+        if (isPush) {
+            if (from != null) {
+                viewAnimators.add(ObjectAnimator.ofFloat(from, View.TRANSLATION_Y, -from.getHeight()));
+            }
+            if (to != null) {
+                viewAnimators.add(ObjectAnimator.ofFloat(to, View.TRANSLATION_Y, to.getHeight(), 0));
+            }
+        } else {
+            if (from != null) {
+                viewAnimators.add(ObjectAnimator.ofFloat(from, View.TRANSLATION_Y, from.getHeight()));
+            }
+            if (to != null) {
+                viewAnimators.add(ObjectAnimator.ofFloat(to, View.TRANSLATION_Y, -to.getHeight(), 0));
+            }
         }
 
         animator.playTogether(viewAnimators);
@@ -46,6 +56,8 @@ public class VerticalChangeHandler extends AnimatorChangeHandler {
     }
 
     @Override
-    protected void resetFromView(@NonNull View from) { }
+    protected void resetFromView(@NonNull View from) {
+        from.setTranslationY(0);
+    }
 
 }


### PR DESCRIPTION
Ensures the previous view is animated on push, and next view is animated on pop.

In my app HorizontalChangeHandler was working fine, but when I switched to VerticalChangeHandler (making no other changes) the animation wouldn't run.

This corrects the issue.