### PR TITLE
Recreate views on config changes

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/internal/LifecycleHandler.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/internal/LifecycleHandler.java
@@ -6,6 +6,7 @@ import android.app.Application.ActivityLifecycleCallbacks;
 import android.app.Fragment;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcel;
@@ -259,6 +260,15 @@ public class LifecycleHandler extends Fragment implements ActivityLifecycleCallb
         }
 
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+
+        for (Router router : routerMap.values()) {
+            router.onConfigurationChanged(newConfig);
+        }
     }
 
     public void registerForActivityResult(@NonNull String instanceId, int requestCode) {


### PR DESCRIPTION
This is typically necessary when the Activity has specified in the manifest that it will handle configuration changes such as an orientation change.

If the top Controller.setRecreateViewOnConfigChange(true) has been called before a configuration change happens, that Controller's current view will be removed and a recreated view will be added to the parent.

For Controllers that are lower in the stack, those Controllers' view will only be recreated if the Controller also has a RetainViewMode of RetainViewMode#RETAIN_DETACH.