### PR TITLE
#Fixes 206

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
@@ -849,6 +849,7 @@ public abstract class Controller {
             onDestroyView(view);
 
             viewAttachHandler.unregisterAttachListener(view);
+            viewAttachHandler = null;
             viewIsAttached = false;
 
             if (isBeingDestroyed) {


### PR DESCRIPTION
Looks like the ViewAttachListeners's object is capturing the "view" and never releasing it here:

https://github.com/bluelinelabs/Conductor/blob/develop/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java#L901