### PR TITLE
Fixes issue when retrieving an existing controller from a ControllerPagerAdapter

### DIFF
--- a/conductor-support/src/main/java/com/bluelinelabs/conductor/support/ControllerPagerAdapter.java
+++ b/conductor-support/src/main/java/com/bluelinelabs/conductor/support/ControllerPagerAdapter.java
@@ -53,12 +53,17 @@ public abstract class ControllerPagerAdapter extends PagerAdapter {
             }
         }
 
+        final Controller controller;
         if (!router.hasRootController()) {
-            Controller controller = getItem(position);
+            controller = getItem(position);
             router.setRoot(RouterTransaction.with(controller).tag(name));
-            visiblePageIds.put(position, controller.getInstanceId());
         } else {
             router.rebindIfNeeded();
+            controller = router.getControllerWithTag(name);
+        }
+
+        if (controller != null) {
+            visiblePageIds.put(position, controller.getInstanceId());
         }
 
         return router.getControllerWithTag(name);


### PR DESCRIPTION
If you page away from a controller then return, `ControllerPagerAdapter#getController()` will not return the controller.  This is due to the controller being removed from `visiblePageIds` in `destroyItem()`, but never added back when the controller is created again.