### PR TITLE
Pass along the correct view state

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
@@ -55,7 +55,7 @@ public abstract class Controller {
     private static final String KEY_OVERRIDDEN_PUSH_HANDLER = "Controller.overriddenPushHandler";
     private static final String KEY_OVERRIDDEN_POP_HANDLER = "Controller.overriddenPopHandler";
     private static final String KEY_VIEW_STATE_HIERARCHY = "Controller.viewState.hierarchy";
-    private static final String KEY_VIEW_STATE_BUNDLE = "Controller.viewState.bundle";
+    static final String KEY_VIEW_STATE_BUNDLE = "Controller.viewState.bundle";
     private static final String KEY_RETAIN_VIEW_MODE = "Controller.retainViewMode";
 
     private final Bundle args;

--- a/conductor/src/main/java/com/bluelinelabs/conductor/RestoreViewOnCreateController.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/RestoreViewOnCreateController.java
@@ -32,7 +32,7 @@ abstract public class RestoreViewOnCreateController extends Controller {
 
     @Override @NonNull
     protected final View onCreateView(@NonNull LayoutInflater inflater, @NonNull ViewGroup container) {
-        return onCreateView(inflater, container, viewState);
+        return onCreateView(inflater, container, viewState == null ? null : viewState.getBundle(KEY_VIEW_STATE_BUNDLE));
     }
 
     /**


### PR DESCRIPTION
The bundle passed in onCreateView is not the one created in onSaveViewState but the "enclosing" view state.