### PR TITLE
Add convenience method Controller.getContext()

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
@@ -282,6 +282,14 @@ public abstract class Controller {
     }
 
     /**
+     * Convenience method equivalent to calling {@link #getActivity()}
+     */
+    @Nullable
+    public final Context getContext() {
+        return getActivity();
+    }
+
+    /**
      * Returns the Resources from the host Activity or {@code null} if this Controller has not
      * yet been attached to an Activity or if the Activity has been destroyed.
      */


### PR DESCRIPTION
Reduces the effort when migrating from Fragments

I recently migrated a project which was heavily using fragments, and it was a (in my opinion unnecessary) pain to go through all of my fragments and replacing getContext calls with getActivity.