### PR TITLE
Fixes ControllerScopeProvider.from return type

### DIFF
--- a/conductor-modules/autodispose/src/main/java/com/bluelinelabs/conductor/autodispose/ControllerScopeProvider.java
+++ b/conductor-modules/autodispose/src/main/java/com/bluelinelabs/conductor/autodispose/ControllerScopeProvider.java
@@ -34,7 +34,7 @@ public class ControllerScopeProvider implements LifecycleScopeProvider<Controlle
 
     @NonNull private final BehaviorSubject<ControllerEvent> lifecycleSubject;
 
-    public static LifecycleScopeProvider from(@NonNull Controller controller) {
+    public static ControllerScopeProvider from(@NonNull Controller controller) {
         return new ControllerScopeProvider(controller);
     }
 


### PR DESCRIPTION
I might be missing something, but looks like the `.from` method should return the specific type instead of the (raw) super type.

Also hope the newline at EOF is okay, if not, happy to remove it ;)