### PR TITLE
Only show options menu of the active item in a ViewPager

### DIFF
--- a/conductor-modules/support/src/main/java/com/bluelinelabs/conductor/support/RouterPagerAdapter.java
+++ b/conductor-modules/support/src/main/java/com/bluelinelabs/conductor/support/RouterPagerAdapter.java
@@ -30,6 +30,7 @@ public abstract class RouterPagerAdapter extends PagerAdapter {
     private SparseArray<Bundle> savedPages = new SparseArray<>();
     private SparseArray<Router> visibleRouters = new SparseArray<>();
     private ArrayList<Integer> savedPageHistory = new ArrayList<>();
+    private Router currentPrimaryRouter;
 
     /**
      * Creates a new RouterPagerAdapter using the passed host.
@@ -77,6 +78,12 @@ public abstract class RouterPagerAdapter extends PagerAdapter {
         router.rebindIfNeeded();
         configureRouter(router, position);
 
+        if (router != currentPrimaryRouter) {
+            for (RouterTransaction transaction : router.getBackstack()) {
+                transaction.controller().setOptionsMenuHidden(true);
+            }
+        }
+
         visibleRouters.put(position, router);
         return router;
     }
@@ -97,6 +104,24 @@ public abstract class RouterPagerAdapter extends PagerAdapter {
         host.removeChildRouter(router);
 
         visibleRouters.remove(position);
+    }
+
+    @Override
+    public void setPrimaryItem(ViewGroup container, int position, Object object) {
+        Router router = (Router)object;
+        if (router != currentPrimaryRouter) {
+            if (currentPrimaryRouter != null) {
+                for (RouterTransaction transaction : currentPrimaryRouter.getBackstack()) {
+                    transaction.controller().setOptionsMenuHidden(true);
+                }
+            }
+            if (router != null) {
+                for (RouterTransaction transaction : router.getBackstack()) {
+                    transaction.controller().setOptionsMenuHidden(false);
+                }
+            }
+            currentPrimaryRouter = router;
+        }
     }
 
     @Override


### PR DESCRIPTION
This PR updates `RouterPagerAdapter` in order to show the toolbar's menu items of the active (primary) page instead of all of them.

It uses the same logic as in [FragmentPagerAdapter](https://github.com/android/platform_frameworks_support/blob/master/fragment/java/android/support/v4/app/FragmentPagerAdapter.java) and I've been using it for a while with no issues, though I'm not sure if the `for` loop should be changed and only enable the options menu of the top controller.

Fixes #244.