### PR TITLE
Fix demo not compiling after dependency updates

### DIFF
--- a/conductor-modules/arch-components-lifecycle/build.gradle
+++ b/conductor-modules/arch-components-lifecycle/build.gradle
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-    api rootProject.ext.archComopnentsLifecycle
+    api rootProject.ext.archComponentsLifecycle
 
     implementation project(':conductor')
 }

--- a/conductor-modules/support/build.gradle
+++ b/conductor-modules/support/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     testImplementation rootProject.ext.junit
     testImplementation rootProject.ext.roboelectric
 
-    implementation rootProject.ext.supportAppCompat
+    implementation rootProject.ext.supportV4
     implementation project(':conductor')
 }
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation rootProject.ext.supportV4
     implementation rootProject.ext.supportDesign
 
+    implementation rootProject.ext.archComponentsLiveDataCore // Fix duplicate classes
+
     annotationProcessor rootProject.ext.butterknifeCompiler
     implementation rootProject.ext.butterknife
     implementation rootProject.ext.picasso

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -41,7 +41,8 @@ ext {
 
     autodispose = "com.uber.autodispose:autodispose:$autodisposeVersion"
 
-    archComopnentsLifecycle = "android.arch.lifecycle:runtime:$archComponentsVersion"
+    archComponentsLifecycle = "android.arch.lifecycle:runtime:$archComponentsVersion"
+    archComponentsLiveDataCore = "android.arch.lifecycle:livedata-core:$archComponentsVersion"
 
     junit = "junit:junit:$junitVersion"
     roboelectric = "org.robolectric:robolectric:$roboelectricVersion"


### PR DESCRIPTION
The support library v4 (27.1.1) [now depends on the architecture components ](https://github.com/aosp-mirror/platform_frameworks_support/blob/support-library-27.1.1/fragment/build.gradle#L14)(1.1.0).

Conductor also uses the architecture components (1.1.1) but the demo can't compile because there's a classpath conflict between versions 1.1.0 and 1.1.1. By explicitly setting the same version for the pulled dependencies the demo compiles again.

I've also changed the dependency on the conductor-support module from appcompat v7 to support v4 since the only usage here is the PagerAdapter from v4.