### PR TITLE
Adds popCurrentController(ControllerChangeHandler) and popController(Controller, ControllerChangeHandler)

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/Router.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Router.java
@@ -110,13 +110,25 @@ public abstract class Router {
     @SuppressWarnings("WeakerAccess")
     @UiThread
     public boolean popCurrentController() {
+        return popCurrentController(null);
+    }
+
+    /**
+     * Pops the top {@link Controller} from the backstack
+     *
+     * @param changeHandler The {@link ControllerChangeHandler} to handle this transaction
+     * @return Whether or not any {@link Controller}s were popped in order to get to the transaction
+     */
+    @SuppressWarnings("WeakerAccess")
+    @UiThread
+    public boolean popCurrentController(@Nullable ControllerChangeHandler changeHandler) {
         ThreadUtils.ensureMainThread();
 
         RouterTransaction transaction = backstack.peek();
         if (transaction == null) {
             throw new IllegalStateException("Trying to pop the current controller when there are none on the backstack.");
         }
-        return popController(transaction.controller);
+        return popController(transaction.controller, changeHandler);
     }
 
     /**
@@ -127,6 +139,18 @@ public abstract class Router {
      */
     @UiThread
     public boolean popController(@NonNull Controller controller) {
+        return popController(controller, null);
+    }
+
+    /**
+     * Pops the passed {@link Controller} from the backstack
+     *
+     * @param controller The {@link Controller} that should be popped from this Router
+     * @param changeHandler The {@link ControllerChangeHandler} that overrides the existing one.
+     * @return Whether or not this Router still has controllers remaining on it after popping.
+     */
+    @UiThread
+    public boolean popController(@NonNull Controller controller, @Nullable ControllerChangeHandler changeHandler) {
         ThreadUtils.ensureMainThread();
 
         RouterTransaction topTransaction = backstack.peek();
@@ -134,7 +158,11 @@ public abstract class Router {
 
         if (poppingTopController) {
             trackDestroyingController(backstack.pop());
-            performControllerChange(backstack.peek(), topTransaction, false);
+            if (changeHandler != null) {
+                performControllerChange(backstack.peek(), topTransaction, false, changeHandler);
+            } else {
+                performControllerChange(backstack.peek(), topTransaction, false);
+            }
         } else {
             RouterTransaction removedTransaction = null;
             RouterTransaction nextTransaction = null;
@@ -159,7 +187,11 @@ public abstract class Router {
             }
 
             if (removedTransaction != null) {
-                performControllerChange(nextTransaction, removedTransaction, false);
+                if (changeHandler != null) {
+                    performControllerChange(nextTransaction, removedTransaction, false, changeHandler);
+                } else {
+                    performControllerChange(nextTransaction, removedTransaction, false);
+                }
             }
         }
 

--- a/demo/src/main/java/com/bluelinelabs/conductor/demo/controllers/NavigationDemoController.java
+++ b/demo/src/main/java/com/bluelinelabs/conductor/demo/controllers/NavigationDemoController.java
@@ -11,6 +11,7 @@ import com.bluelinelabs.conductor.ControllerChangeHandler;
 import com.bluelinelabs.conductor.ControllerChangeType;
 import com.bluelinelabs.conductor.RouterTransaction;
 import com.bluelinelabs.conductor.changehandler.HorizontalChangeHandler;
+import com.bluelinelabs.conductor.changehandler.VerticalChangeHandler;
 import com.bluelinelabs.conductor.demo.R;
 import com.bluelinelabs.conductor.demo.controllers.base.BaseController;
 import com.bluelinelabs.conductor.demo.util.BundleBuilder;
@@ -71,6 +72,8 @@ public class NavigationDemoController extends BaseController {
 
         if (displayUpMode != DisplayUpMode.SHOW) {
             view.findViewById(R.id.btn_up).setVisibility(View.GONE);
+            view.findViewById(R.id.btn_back).setVisibility(View.GONE);
+            view.findViewById(R.id.btn_back_override).setVisibility(View.GONE);
         }
 
         view.setBackgroundColor(ColorUtil.getMaterialColor(getResources(), index));
@@ -101,6 +104,8 @@ public class NavigationDemoController extends BaseController {
         if (view != null) {
             view.findViewById(R.id.btn_next).setEnabled(enabled);
             view.findViewById(R.id.btn_up).setEnabled(enabled);
+            view.findViewById(R.id.btn_back).setEnabled(enabled);
+            view.findViewById(R.id.btn_back_override).setEnabled(enabled);
             view.findViewById(R.id.btn_pop_to_root).setEnabled(enabled);
         }
     }
@@ -113,6 +118,14 @@ public class NavigationDemoController extends BaseController {
 
     @OnClick(R.id.btn_up) void onUpClicked() {
         getRouter().popToTag(TAG_UP_TRANSACTION);
+    }
+
+    @OnClick(R.id.btn_back) void onBackClicked() {
+        getRouter().popCurrentController();
+    }
+
+    @OnClick(R.id.btn_back_override) void onBackOverrideClicked() {
+        getRouter().popCurrentController(new VerticalChangeHandler());
     }
 
     @OnClick(R.id.btn_pop_to_root) void onPopToRootClicked() {

--- a/demo/src/main/res/layout/controller_navigation_demo.xml
+++ b/demo/src/main/res/layout/controller_navigation_demo.xml
@@ -39,6 +39,24 @@
             />
 
         <Button
+            android:id="@+id/btn_back"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:text="@string/go_back"
+            style="?android:attr/buttonBarButtonStyle"
+            />
+
+        <Button
+            android:id="@+id/btn_back_override"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:text="@string/go_back_override"
+            style="?android:attr/buttonBarButtonStyle"
+            />
+
+        <Button
             android:id="@+id/btn_next"
             android:layout_width="0dp"
             android:layout_height="match_parent"

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <!-- Navigation Demo -->
     <string name="pop_to_root">Pop to Root</string>
     <string name="go_up">Go Up</string>
+    <string name="go_back">Go Back</string>
+    <string name="go_back_override">Go Back and Override Handler</string>
     <string name="next_controller">Next Controller</string>
     <string name="navigation_title">Controller #%1$d</string>
 


### PR DESCRIPTION
### About

Hello, thank you for this nice framework.
I am currently using it for one of my apps and it is lovely 👏 

One case I ran into was when I needed to be able to pop the top controller but with a different `ChangeHandler` than what was setup previously, due to the dynamic design of the app I am working with. In this case, the particular controller is not a `root` controller but the top one. 

So I felt it could be nice to have a `popCurrentController(ControllerChangeHandler)` method as well since that would avoid the need for tagging and using `popToTag(String, ControllerChangeHandler)`  in my current case.
But there was only a  `popCurrentController()` method, so I suggest to add this as well as `popController(Controller, ControllerChangeHandler)` 

### Changes

So this PR changes two things:

1. Adds `popCurrentController(ControllerChangeHandler): boolean` and `popController(Controller, ControllerChangeHandler): boolean` in `Router.java`
This makes the pop method list look like this:

```java
popCurrentController(): boolean
>popCurrentController(ControllerChangeHandler): boolean
popController(Controller): boolean
>popController(Controller, ControllerChangeHandler): boolean
popToRoot(): boolean
popToRoot(ControllerChangeHandler): boolean
popToTag(String): boolean
popToTag(String, ControllerChangeHandler): boolean
```

2. Demos the functionality in the navigation demos,
by showing a `Go Back` and `Go Back and Override Handler` buttons.
`Go Back and Override Handler` demos changing the already set `HorizontalChangeHandler` to a `VerticalChangeHandler`

<img src="https://user-images.githubusercontent.com/2103775/44311704-371b0e80-a427-11e8-93e9-a277879451eb.gif" width="600" />
