### PR TITLE
Implement Bottom navigation tab with own back stack in each tab

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/changehandler/SimpleSwapChangeHandler.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/changehandler/SimpleSwapChangeHandler.java
@@ -19,10 +19,10 @@ public class SimpleSwapChangeHandler extends ControllerChangeHandler implements 
 
     private boolean removesFromViewOnPush;
 
-    private boolean canceled;
+    protected boolean canceled;
 
-    private ViewGroup container;
-    private ControllerChangeCompletedListener changeListener;
+    protected ViewGroup container;
+    protected ControllerChangeCompletedListener changeListener;
 
     public SimpleSwapChangeHandler() {
         this(true);

--- a/conductor/src/main/java/com/bluelinelabs/conductor/changehandler/SwapTabChangeHandler.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/changehandler/SwapTabChangeHandler.java
@@ -1,0 +1,40 @@
+package com.bluelinelabs.conductor.changehandler;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.bluelinelabs.conductor.ControllerChangeHandler;
+
+/**
+ * A {@link ControllerChangeHandler} that will instantly swap Views with no animations or transitions.
+ */
+public class SwapTabChangeHandler extends SimpleSwapChangeHandler {
+
+  public SwapTabChangeHandler() {
+  }
+
+
+  @Override
+  public void performChange(@NonNull ViewGroup container, @Nullable View from, @Nullable View to, boolean isPush, @NonNull ControllerChangeCompletedListener changeListener) {
+    if (!canceled) {
+      if (from != null) {
+        container.removeView(from);
+      }
+
+      if (to != null && to.getParent() == null) {
+        container.addView(to);
+      }
+    }
+
+    if (container.getWindowToken() != null) {
+      changeListener.onChangeCompleted();
+    } else {
+      this.changeListener = changeListener;
+      this.container = container;
+      container.addOnAttachStateChangeListener(this);
+    }
+
+  }
+}


### PR DESCRIPTION
@EricKuck I'll try to implement Bottom navigation tab with own back stack. It works, but it would be great if you review this code because I can miss some edge cases.

In #316 when you switch tab, the previous router destroyed all controllers in a stack, so if you try using MVP pattern it does not work because all presenters destroyed with controllers. In my implementation, it's alive and has the same lifecycle as a standard controller.