### PR TITLE
Upgrade AutoDispose to 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: android
 android:
   components:
     - tools
-    - build-tools-27.0.3
-    - android-27
+    - build-tools-28.0.3
+    - android-28
     - extra-android-m2repository
   licenses:
     - '.+'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,7 +10,7 @@ ext {
     rxJava2Version = '2.1.14'
     rxLifecycleVersion = '1.0'
     rxLifecycle2Version = '2.2.1'
-    autodisposeVersion = '1.0.0-RC2'
+    autodisposeVersion = '1.0.0'
     archComponentsVersion = '2.0.0'
     junitVersion = '4.12'
     roboelectricVersion = '3.8'


### PR DESCRIPTION
This upgrades AutoDispose to 1.0.0. With Conductor having moved to AndroidX, this should be compatible. 