### PR TITLE
Ab/agp 3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
     }
 }
 

--- a/conductor-lint/build.gradle
+++ b/conductor-lint/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
-targetCompatibility = JavaVersion.VERSION_1_7
-sourceCompatibility = JavaVersion.VERSION_1_7
+targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_1_8
 
 configurations {
     lintChecks

--- a/conductor-modules/arch-components-lifecycle/build.gradle
+++ b/conductor-modules/arch-components-lifecycle/build.gradle
@@ -7,8 +7,8 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     defaultConfig {

--- a/conductor-modules/autodispose/build.gradle
+++ b/conductor-modules/autodispose/build.gradle
@@ -7,8 +7,8 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     defaultConfig {

--- a/conductor-modules/rxlifecycle/build.gradle
+++ b/conductor-modules/rxlifecycle/build.gradle
@@ -7,8 +7,8 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     defaultConfig {

--- a/conductor-modules/rxlifecycle2/build.gradle
+++ b/conductor-modules/rxlifecycle2/build.gradle
@@ -7,8 +7,8 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     defaultConfig {

--- a/conductor-modules/support/build.gradle
+++ b/conductor-modules/support/build.gradle
@@ -14,8 +14,8 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     defaultConfig {

--- a/conductor/build.gradle
+++ b/conductor/build.gradle
@@ -14,8 +14,8 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     defaultConfig {

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -4,8 +4,8 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     defaultConfig {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,7 +3,7 @@ ext {
     compileSdkVersion = 28
     targetSdkVersion = 28
 
-    butterknifeVersion = '9.0.0-rc1'
+    butterknifeVersion = '10.0.0'
     picassoVersion = '2.5.2'
     leakCanaryVersion = '1.5.4'
     rxJavaVersion = '1.3.8'


### PR DESCRIPTION
After having downloaded AS 3.3, doing a clean build would produce the following error:
```
Invoke-customs are only supported starting with Android O (--min-api 26)
```
Targeting Java 8 fixed the problem

Also upgraded AGP to 3.3.0, which also required butterknife to be updated due to the following error:
```
The given artifact contains a string literal with a package reference 'android.support.v4.content' that cannot be safely rewritten. for androidx
```
Updating ButterKnife fixes this problem since 10.0.0 targets only androidx