### PR TITLE
Add ControllerFactory.

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/Conductor.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Conductor.java
@@ -41,4 +41,7 @@ public final class Conductor {
         return router;
     }
 
+    public static void setControllerFactory(@NonNull ControllerFactory factory) {
+        Controller.FACTORY = factory;
+    }
 }

--- a/conductor/src/main/java/com/bluelinelabs/conductor/ControllerFactory.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/ControllerFactory.java
@@ -1,0 +1,10 @@
+package com.bluelinelabs.conductor;
+
+import android.os.Bundle;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public interface ControllerFactory {
+    @Nullable
+    Controller create(@NonNull String controllerName, @Nullable Bundle args);
+}

--- a/conductor/src/main/java/com/bluelinelabs/conductor/DefaultControllerFactory.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/DefaultControllerFactory.java
@@ -1,0 +1,16 @@
+package com.bluelinelabs.conductor;
+
+import android.os.Bundle;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+final class DefaultControllerFactory implements ControllerFactory {
+
+    static final DefaultControllerFactory INSTANCE = new DefaultControllerFactory();
+
+    @Nullable
+    @Override
+    public final Controller create(@NonNull String controllerName, @Nullable Bundle args) {
+        return null;
+    }
+}

--- a/conductor/src/test/java/com/bluelinelabs/conductor/ControllerFactoryTests.java
+++ b/conductor/src/test/java/com/bluelinelabs/conductor/ControllerFactoryTests.java
@@ -1,0 +1,66 @@
+package com.bluelinelabs.conductor;
+
+import android.os.Bundle;
+import com.bluelinelabs.conductor.util.ActivityProxy;
+import com.bluelinelabs.conductor.util.TestController;
+import com.bluelinelabs.conductor.util.TestControllerFactory;
+import com.bluelinelabs.conductor.util.TestDependenciesController;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class ControllerFactoryTests {
+
+    private Router router;
+
+    private ActivityProxy activityProxy;
+
+    public void createActivityController(Bundle savedInstanceState, boolean includeStartAndResume) {
+        activityProxy = new ActivityProxy().create(savedInstanceState);
+
+        if (includeStartAndResume) {
+            activityProxy.start().resume();
+        }
+        router = Conductor.attachRouter(activityProxy.getActivity(), activityProxy.getView(), savedInstanceState);
+        if (!router.hasRootController()) {
+            router.setRoot(RouterTransaction.with(new TestController()));
+        }
+    }
+
+    @Before
+    public void setup() {
+        Conductor.setControllerFactory(new TestControllerFactory());
+        createActivityController(null, true);
+    }
+
+    @Test
+    public void testControllerWithDependenciesRecreated() {
+        Bundle args = new Bundle();
+        args.putBoolean(TestDependenciesController.WAS_RECREATED_WITH_BUNDLE_ARGS, true);
+        TestDependenciesController controller = new TestDependenciesController(args, false);
+        router.pushController(RouterTransaction.with(controller)
+                .tag("root"));
+        activityProxy.getActivity().isChangingConfigurations = true;
+
+        assertEquals(false, controller.wasCreatedByFactory);
+        assertEquals(false, controller.wasInstanceStateRestored);
+
+        Bundle bundle = new Bundle();
+        activityProxy.saveInstanceState(bundle);
+        activityProxy.pause();
+        activityProxy.stop(true);
+        activityProxy.destroy();
+
+        createActivityController(bundle, false);
+        controller = (TestDependenciesController)router.getControllerWithTag("root");
+        assertEquals(true, controller.wasCreatedByFactory);
+        assertEquals(true, controller.wasInstanceStateRestored);
+        assertEquals(true, controller.wasRecreatedWithBundleArgs);
+    }
+}

--- a/conductor/src/test/java/com/bluelinelabs/conductor/util/TestControllerFactory.java
+++ b/conductor/src/test/java/com/bluelinelabs/conductor/util/TestControllerFactory.java
@@ -1,0 +1,20 @@
+package com.bluelinelabs.conductor.util;
+
+import android.os.Bundle;
+
+import com.bluelinelabs.conductor.Controller;
+import com.bluelinelabs.conductor.ControllerFactory;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class TestControllerFactory implements ControllerFactory {
+    @Nullable
+    @Override
+    public Controller create(@NonNull String controllerName, @Nullable Bundle args) {
+        if (controllerName.equals(TestDependenciesController.class.getName())) {
+            return new TestDependenciesController(args, true);
+        }
+        return null;
+    }
+}

--- a/conductor/src/test/java/com/bluelinelabs/conductor/util/TestDependenciesController.java
+++ b/conductor/src/test/java/com/bluelinelabs/conductor/util/TestDependenciesController.java
@@ -1,0 +1,41 @@
+package com.bluelinelabs.conductor.util;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.bluelinelabs.conductor.Controller;
+
+import androidx.annotation.NonNull;
+
+public class TestDependenciesController extends Controller {
+
+    public static final String WAS_RECREATED_WITH_BUNDLE_ARGS = "WAS_RECREATED_WITH_BUNDLE_ARGS";
+    private static final String INSTANCE_STATE = "INSTANCE_STATE";
+    public final Boolean wasCreatedByFactory;
+    public Boolean wasInstanceStateRestored = false;
+    public final Boolean wasRecreatedWithBundleArgs;
+
+    public TestDependenciesController(Bundle args, Boolean wasCreatedByFactory) {
+        super(args);
+        this.wasRecreatedWithBundleArgs = args.getBoolean(WAS_RECREATED_WITH_BUNDLE_ARGS, false);
+        this.wasCreatedByFactory = wasCreatedByFactory;
+    }
+
+    @NonNull
+    @Override
+    protected View onCreateView(@NonNull LayoutInflater inflater, @NonNull ViewGroup container) {
+        return new AttachFakingFrameLayout(inflater.getContext());
+    }
+
+    @Override protected void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putBoolean(INSTANCE_STATE, true);
+    }
+
+    @Override protected void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+        wasInstanceStateRestored = savedInstanceState.getBoolean(INSTANCE_STATE);
+    }
+}


### PR DESCRIPTION
ControllerFactory allows Controllers to be provided dependencies through their constructors after a configuration change. This means field injection is no longer a requirement when injecting dependencies into a Controller.

**Usage**
```
Conductor.setControllerFactory(myControllerFactory)
```

Currently, you have a single `ControllerFactory` for your entire app. Having a ControllerFactory per `Activity/ViewGroup` would be better but I don't know enough about Conductors internals to make that change.

Closes #510.