### PR TITLE
Add ChangeHandlerCoordinatorLayout

### DIFF
--- a/conductor-modules/support/build.gradle
+++ b/conductor-modules/support/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     testImplementation rootProject.ext.roboelectric
 
     implementation rootProject.ext.androidxAppCompat
+    implementation rootProject.ext.androidxCoordinatorLayout
     implementation project(':conductor')
 }
 

--- a/conductor-modules/support/src/main/java/com/bluelinelabs/conductor/support/ChangeHandlerCoordinatorLayout.java
+++ b/conductor-modules/support/src/main/java/com/bluelinelabs/conductor/support/ChangeHandlerCoordinatorLayout.java
@@ -1,0 +1,65 @@
+package com.bluelinelabs.conductor.support;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.ViewGroup;
+import android.view.WindowInsets;
+
+import androidx.annotation.AttrRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+
+import com.bluelinelabs.conductor.Controller;
+import com.bluelinelabs.conductor.ControllerChangeHandler;
+import com.bluelinelabs.conductor.ControllerChangeHandler.ControllerChangeListener;
+
+/**
+ * A CoordinatorLayout implementation that can be used to block user interactions while
+ * {@link ControllerChangeHandler}s are performing changes. It also propagates WindowInset changes
+ * to its children to allow the creation of immersive layouts using fitsSystemWindows
+ */
+public class ChangeHandlerCoordinatorLayout extends CoordinatorLayout implements ControllerChangeListener {
+
+    private int inProgressTransactionCount;
+
+    public ChangeHandlerCoordinatorLayout(@NonNull Context context) {
+        super(context);
+    }
+
+    public ChangeHandlerCoordinatorLayout(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public ChangeHandlerCoordinatorLayout(@NonNull Context context, @Nullable AttributeSet attrs, @AttrRes int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev) {
+        return (inProgressTransactionCount > 0) || super.onInterceptTouchEvent(ev);
+    }
+
+    @Override
+    public void onChangeStarted(@Nullable Controller to, @Nullable Controller from, boolean isPush, @NonNull ViewGroup container, @NonNull ControllerChangeHandler handler) {
+        inProgressTransactionCount++;
+    }
+
+    @Override
+    public void onChangeCompleted(@Nullable Controller to, @Nullable Controller from, boolean isPush, @NonNull ViewGroup container, @NonNull ControllerChangeHandler handler) {
+        inProgressTransactionCount--;
+    }
+
+    @Override
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    public WindowInsets onApplyWindowInsets(WindowInsets insets) {
+        for(int i = 0; i < getChildCount(); i++) {
+            getChildAt(i).dispatchApplyWindowInsets(insets);
+        }
+
+        return super.onApplyWindowInsets(insets);
+    }
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -19,6 +19,7 @@ ext {
     material = "com.google.android.material:material:1.0.0"
     androidxAnnotations = "androidx.annotation:annotation:1.0.0"
     androidxAppCompat = "androidx.appcompat:appcompat:1.0.0"
+    androidxCoordinatorLayout = "androidx.coordinatorlayout:coordinatorlayout:1.0.0"
 
     butterknife = "com.jakewharton:butterknife:$butterknifeVersion"
     butterknifeCompiler = "com.jakewharton:butterknife-compiler:$butterknifeVersion"


### PR DESCRIPTION
The default `FrameLayout`-based ChangeHandler viewgroup is great for basic purposes, but if one wants to have a complete single activity app, and needs to access e.g. `fitsSystemWindows` with Google's swap (Material library component viewgroups such as CoordinatorLayout, ConstraintLayout, etc. sort of "reverse" how `fitsSystemWindows` works and make it easier to work with), and of course child propagation for this property (and any property touching window insets), they're out of luck.

This control should alleviate most of those "damn there's no ready-made solution for this" headaches some developers might have. 