### PR TITLE
Fix #527, Memory leak in SharedElementTransitionChangeHandler

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/changehandler/SharedElementTransitionChangeHandler.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/changehandler/SharedElementTransitionChangeHandler.java
@@ -100,6 +100,13 @@ public abstract class SharedElementTransitionChangeHandler extends TransitionCha
         removedViews.clear();
     }
 
+    @Override
+    protected void onEnd() {
+        exitTransition = null;
+        enterTransition = null;
+        sharedElementTransition = null;
+    }
+
     void configureTransition(@NonNull final ViewGroup container, @Nullable View from, @Nullable View to, @NonNull final Transition transition, boolean isPush) {
         final View nonExistentView = new View(container.getContext());
 


### PR DESCRIPTION
Nice easy fix for #527. These three transitions were holding references to views after they had finished, creating a memory leak. Now they're cleared in `onEnd()`, ensuring we're not holding on to anything we shouldn't.