### PR TITLE
Fixed crash in release builds when using ChangeHandler with flag removesFromViewOnPush=false

### DIFF
--- a/conductor/proguard-rules.txt
+++ b/conductor/proguard-rules.txt
@@ -1,5 +1,9 @@
-# Retain constructor that is called by using reflection to recreate the Controller
+# Retain constructor that is called by using reflection to recreate the Controller or ChangeHandler
 -keepclassmembers public class * extends com.bluelinelabs.conductor.Controller {
+   public <init>();
+   public <init>(android.os.Bundle);
+}
+-keepclassmembers public class * extends com.bluelinelabs.conductor.ControllerChangeHandler {
    public <init>();
    public <init>(android.os.Bundle);
 }


### PR DESCRIPTION
To avoid crashes like "java.lang.RuntimeException: class c.f.a.a.l.a.b does not have a default constructor" in release builds.
