### PR TITLE
Add failing instrumented tests for detecting stuck TransitionChangeHandlers

### DIFF
--- a/conductor/build.gradle
+++ b/conductor/build.gradle
@@ -24,6 +24,7 @@ android {
         versionCode Integer.parseInt(project.VERSION_CODE)
         versionName project.VERSION_NAME
         consumerProguardFiles 'proguard-rules.txt'
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 }
 
@@ -34,6 +35,9 @@ configurations {
 dependencies {
     testImplementation rootProject.ext.junit
     testImplementation rootProject.ext.roboelectric
+    androidTestImplementation rootProject.ext.junit
+    androidTestImplementation rootProject.ext.androidxTestRules
+    androidTestImplementation rootProject.ext.espressoCore
 
     api rootProject.ext.androidxAnnotations
 

--- a/conductor/src/androidTest/AndroidManifest.xml
+++ b/conductor/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.bluelinelabs.conductor"
+    >
+
+    <application>
+
+        <activity android:name=".util.TestActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+    </application>
+
+</manifest>

--- a/conductor/src/androidTest/java/com/bluelinelabs/conductor/TransitionChangeHandlerTests.java
+++ b/conductor/src/androidTest/java/com/bluelinelabs/conductor/TransitionChangeHandlerTests.java
@@ -1,0 +1,105 @@
+package com.bluelinelabs.conductor;
+
+import android.view.View;
+import android.view.ViewGroup;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.test.espresso.Espresso;
+import androidx.test.espresso.IdlingRegistry;
+import androidx.test.espresso.IdlingResource;
+import androidx.test.espresso.idling.CountingIdlingResource;
+import androidx.test.rule.ActivityTestRule;
+import com.bluelinelabs.conductor.util.EmptyTestController;
+import com.bluelinelabs.conductor.util.TestActivity;
+import com.bluelinelabs.conductor.util.TestTransitionChangeHandler;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TransitionChangeHandlerTests {
+
+    @Rule
+    public ActivityTestRule<TestActivity> activityTestRule = new ActivityTestRule<>(TestActivity.class);
+    private Router router;
+    private int runningTransactions = 0;
+
+    @Before
+    public void setup() {
+        router = activityTestRule.getActivity().router;
+        router.addChangeListener(new ControllerChangeHandler.ControllerChangeListener() {
+            @Override
+            public void onChangeStarted(@Nullable Controller to, @Nullable Controller from, boolean isPush, @NonNull ViewGroup container, @NonNull ControllerChangeHandler handler) {
+                runningTransactions++;
+            }
+
+            @Override
+            public void onChangeCompleted(@Nullable Controller to, @Nullable Controller from, boolean isPush, @NonNull ViewGroup container, @NonNull ControllerChangeHandler handler) {
+                runningTransactions--;
+            }
+        });
+    }
+
+    @Test
+    public void testPushPop() throws Throwable {
+        final EmptyTestController rootController = new EmptyTestController();
+        IdlingRegistry.getInstance().register(idlingResourceUntilControllerAttachedDelayed(rootController));
+        activityTestRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                router.setRoot(RouterTransaction.with(rootController));
+
+                router.pushController(RouterTransaction.with(new EmptyTestController())
+                        .pushChangeHandler(new TestTransitionChangeHandler())
+                        .popChangeHandler(new TestTransitionChangeHandler()));
+                router.popCurrentController();
+            }
+        });
+
+        Espresso.onIdle();
+        assertEquals(0, runningTransactions);
+    }
+
+    @Test
+    public void testDoublePush() throws Throwable {
+        final EmptyTestController topController = new EmptyTestController();
+        IdlingRegistry.getInstance().register(idlingResourceUntilControllerAttachedDelayed(topController));
+        activityTestRule.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                router.setRoot(RouterTransaction.with(new EmptyTestController()));
+
+                router.pushController(RouterTransaction.with(new EmptyTestController())
+                        .pushChangeHandler(new TestTransitionChangeHandler())
+                        .popChangeHandler(new TestTransitionChangeHandler()));
+                router.pushController(RouterTransaction.with(topController)
+                        .pushChangeHandler(new TestTransitionChangeHandler())
+                        .popChangeHandler(new TestTransitionChangeHandler()));
+            }
+        });
+
+        Espresso.onIdle();
+        assertEquals(0, runningTransactions);
+    }
+
+    private IdlingResource idlingResourceUntilControllerAttachedDelayed(Controller controller) {
+        final CountingIdlingResource idlingResource = new CountingIdlingResource("attached_" + controller.instanceId);
+        idlingResource.increment();
+        controller.addLifecycleListener(new Controller.LifecycleListener() {
+            @Override
+            public void postAttach(@NonNull final Controller controller, @NonNull View view) {
+                controller.removeLifecycleListener(this);
+                view.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        idlingResource.decrement();
+                    }
+                }, 3000L);
+            }
+        });
+
+        return idlingResource;
+    }
+
+}

--- a/conductor/src/androidTest/java/com/bluelinelabs/conductor/util/EmptyTestController.java
+++ b/conductor/src/androidTest/java/com/bluelinelabs/conductor/util/EmptyTestController.java
@@ -1,0 +1,16 @@
+package com.bluelinelabs.conductor.util;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import androidx.annotation.NonNull;
+import com.bluelinelabs.conductor.Controller;
+
+public class EmptyTestController extends Controller {
+    @NonNull
+    @Override
+    protected View onCreateView(@NonNull LayoutInflater inflater, @NonNull ViewGroup container) {
+        return new FrameLayout(container.getContext());
+    }
+}

--- a/conductor/src/androidTest/java/com/bluelinelabs/conductor/util/TestActivity.java
+++ b/conductor/src/androidTest/java/com/bluelinelabs/conductor/util/TestActivity.java
@@ -1,0 +1,23 @@
+package com.bluelinelabs.conductor.util;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.ViewGroup;
+import androidx.annotation.Nullable;
+import com.bluelinelabs.conductor.Conductor;
+import com.bluelinelabs.conductor.Router;
+import com.bluelinelabs.conductor.test.R;
+
+public class TestActivity extends Activity {
+
+    public Router router;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.activity_test);
+
+        router = Conductor.attachRouter(this, (ViewGroup) findViewById(R.id.test_root), savedInstanceState);
+    }
+}

--- a/conductor/src/androidTest/java/com/bluelinelabs/conductor/util/TestTransitionChangeHandler.java
+++ b/conductor/src/androidTest/java/com/bluelinelabs/conductor/util/TestTransitionChangeHandler.java
@@ -1,0 +1,17 @@
+package com.bluelinelabs.conductor.util;
+
+import android.transition.Slide;
+import android.transition.Transition;
+import android.view.View;
+import android.view.ViewGroup;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.bluelinelabs.conductor.changehandler.TransitionChangeHandler;
+
+public class TestTransitionChangeHandler extends TransitionChangeHandler {
+    @NonNull
+    @Override
+    protected Transition getTransition(@NonNull ViewGroup container, @Nullable View from, @Nullable View to, boolean isPush) {
+        return new Slide();
+    }
+}

--- a/conductor/src/androidTest/res/layout/activity_test.xml
+++ b/conductor/src/androidTest/res/layout/activity_test.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.bluelinelabs.conductor.ChangeHandlerFrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/test_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    />

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -14,6 +14,8 @@ ext {
     archComponentsVersion = '2.0.0'
     junitVersion = '4.12'
     roboelectricVersion = '3.8'
+    androidxTestVersion = '1.2.0'
+    espressoVersion = '3.2.0'
     lintVersion = '26.1.2'
 
     material = "com.google.android.material:material:1.0.0"
@@ -45,6 +47,9 @@ ext {
 
     junit = "junit:junit:$junitVersion"
     roboelectric = "org.robolectric:robolectric:$roboelectricVersion"
+
+    androidxTestRules = "androidx.test:rules:$androidxTestVersion"
+    espressoCore = "androidx.test.espresso:espresso-core:$espressoVersion"
 
     lintapi = "com.android.tools.lint:lint-api:$lintVersion"
     lintchecks = "com.android.tools.lint:lint-checks:$lintVersion"


### PR DESCRIPTION
This adds two (currently failing) test cases that demonstrate #545. They're unfortunately instrumented tests rather than Robolectric tests, because Robolectric doesn't have mocks for Transitions.