### PR TITLE
Fix TransitionChangeHandlers getting stuck when two are run simultaneously

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/changehandler/TransitionChangeHandler.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/changehandler/TransitionChangeHandler.java
@@ -70,7 +70,6 @@ public abstract class TransitionChangeHandler extends ControllerChangeHandler {
         final Runnable onTransitionNotStarted = new Runnable() {
             @Override
             public void run() {
-                executePropertyChanges(container, from, to, null, isPush);
                 changeListener.onChangeCompleted();
             }
         };

--- a/conductor/src/main/java/com/bluelinelabs/conductor/changehandler/TransitionChangeHandler.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/changehandler/TransitionChangeHandler.java
@@ -67,10 +67,20 @@ public abstract class TransitionChangeHandler extends ControllerChangeHandler {
             return;
         }
 
+        final Runnable onTransitionNotStarted = new Runnable() {
+            @Override
+            public void run() {
+                executePropertyChanges(container, from, to, null, isPush);
+                changeListener.onChangeCompleted();
+            }
+        };
+
         final Transition transition = getTransition(container, from, to, isPush);
         transition.addListener(new TransitionListener() {
             @Override
-            public void onTransitionStart(Transition transition) { }
+            public void onTransitionStart(Transition transition) {
+                container.removeCallbacks(onTransitionNotStarted);
+            }
 
             @Override
             public void onTransitionEnd(Transition transition) {
@@ -97,6 +107,7 @@ public abstract class TransitionChangeHandler extends ControllerChangeHandler {
                 if (!canceled) {
                     TransitionManager.beginDelayedTransition(container, transition);
                     executePropertyChanges(container, from, to, transition, isPush);
+                    container.post(onTransitionNotStarted);
                 }
             }
         });


### PR DESCRIPTION
Fixes #545 and the failing test cases in #546.
This takes a defensive approach against the Transition API which, according to its docs, won't run a transition if another transition has already been added for the same scene root in the same frame. It checks to see if the transition has been started by the next frame, and if it hasn't, immediately runs the changes.