### PR TITLE
Keep ControllerChangeHandler default constructor in Proguard rules

### DIFF
--- a/conductor/proguard-rules.txt
+++ b/conductor/proguard-rules.txt
@@ -3,3 +3,6 @@
    public <init>();
    public <init>(android.os.Bundle);
 }
+-keepclassmembers public class * extends com.bluelinelabs.conductor.ControllerChangeHandler {
+   public <init>();
+}


### PR DESCRIPTION
They can currently be stripped out, causing `ensureDefaultConstructor()` to fail.