### PR TITLE
Fix #563 bug: Controller in the middle of a backstack isn't destroyed after calling popController

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/Router.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Router.java
@@ -146,9 +146,7 @@ public abstract class Router {
             while (iterator.hasNext()) {
                 RouterTransaction transaction = iterator.next();
                 if (transaction.controller == controller) {
-                    if (controller.isAttached()) {
-                        trackDestroyingController(transaction);
-                    }
+                    trackDestroyingController(transaction);
                     iterator.remove();
                     removedTransaction = transaction;
                 } else if (removedTransaction != null) {
@@ -782,7 +780,7 @@ public abstract class Router {
         performControllerChange(to, from, isPush, changeHandler);
     }
 
-    void performControllerChange(@Nullable RouterTransaction to, @Nullable RouterTransaction from, boolean isPush, @Nullable ControllerChangeHandler changeHandler) {
+    private void performControllerChange(@Nullable RouterTransaction to, @Nullable RouterTransaction from, boolean isPush, @Nullable ControllerChangeHandler changeHandler) {
         Controller toController = to != null ? to.controller : null;
         Controller fromController = from != null ? from.controller : null;
         boolean forceDetachDestroy = false;
@@ -795,12 +793,21 @@ public abstract class Router {
             // Activity or controller should be handling this by finishing or at least hiding this view.
             changeHandler = new NoOpControllerChangeHandler();
             forceDetachDestroy = true;
+        } else if (!isPush && fromController != null && !fromController.isAttached()) {
+            // We're popping fromController from the middle of the backstack,
+            // need to do it immediately and destroy the controller
+            changeHandler = new NoOpControllerChangeHandler();
+            forceDetachDestroy = true;
         }
 
         performControllerChange(toController, fromController, isPush, changeHandler);
 
-        if (forceDetachDestroy && fromController != null && fromController.getView() != null) {
-            fromController.detach(fromController.getView(), true, false);
+        if (forceDetachDestroy && fromController != null) {
+            if (fromController.getView() != null) {
+                fromController.detach(fromController.getView(), true, false);
+            } else {
+                fromController.destroy();
+            }
         }
     }
 

--- a/conductor/src/test/java/com/bluelinelabs/conductor/ControllerLifecycleCallbacksTests.java
+++ b/conductor/src/test/java/com/bluelinelabs/conductor/ControllerLifecycleCallbacksTests.java
@@ -446,6 +446,38 @@ public class ControllerLifecycleCallbacksTests {
     }
 
     @Test
+    public void testLifecycleWhenPopNonCurrentController() {
+        String controller1Tag = "controller1";
+        String controller2Tag = "controller2";
+        String controller3Tag = "controller3";
+
+        TestController controller1 = new TestController();
+        TestController controller2 = new TestController();
+        TestController controller3 = new TestController();
+
+        router.pushController(RouterTransaction.with(controller1)
+                .tag(controller1Tag));
+
+        router.pushController(RouterTransaction.with(controller2)
+                .tag(controller2Tag));
+
+        router.pushController(RouterTransaction.with(controller3)
+                .tag(controller3Tag));
+
+        router.popController(controller2);
+
+        assertEquals(1, controller2.currentCallState.attachCalls);
+        assertEquals(1, controller2.currentCallState.createViewCalls);
+        assertEquals(1, controller2.currentCallState.detachCalls);
+        assertEquals(1, controller2.currentCallState.destroyViewCalls);
+        assertEquals(1, controller2.currentCallState.destroyCalls);
+        assertEquals(1, controller2.currentCallState.contextAvailableCalls);
+        assertEquals(1, controller2.currentCallState.contextUnavailableCalls);
+        assertEquals(1, controller2.currentCallState.saveViewStateCalls);
+        assertEquals(0, controller2.currentCallState.restoreViewStateCalls);
+    }
+
+    @Test
     public void testChildLifecycle() {
         Controller parent = new TestController();
         router.pushController(RouterTransaction.with(parent)


### PR DESCRIPTION
When I call popController for a controller in the middle of a backstack the Controller.performDestroy isn't called but the view of the controller is removed and the controller is removed from the backstask.

As popController has the flow for false poppingTopController I suppose everything should have worked correctly.

The original issue is here: https://github.com/bluelinelabs/Conductor/issues/563