### PR TITLE
Fix Conductor pending changes lock, related to #287 discussion

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/Router.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Router.java
@@ -633,10 +633,13 @@ public abstract class Router {
     }
 
     public void prepareForHostDetach() {
+        pendingControllerChanges.clear(); // rely on backstack based restoration in rebindIfNeeded
+
         for (RouterTransaction transaction : backstack) {
             if (ControllerChangeHandler.completeHandlerImmediately(transaction.controller.getInstanceId())) {
                 transaction.controller.setNeedsAttach(true);
             }
+
             transaction.controller.prepareForHostDetach();
         }
     }
@@ -814,11 +817,17 @@ public abstract class Router {
         if (pendingControllerChanges.size() > 0) {
             // If we already have changes queued up (awaiting full container attach), queue this one up as well so they don't happen
             // out of order.
+            if (to != null) {
+                to.setNeedsAttach(true);
+            }
             pendingControllerChanges.add(transaction);
         } else if (from != null && (changeHandler == null || changeHandler.removesFromViewOnPush()) && !containerFullyAttached) {
             // If the change handler will remove the from view, we have to make sure the container is fully attached first so we avoid NPEs
             // within ViewGroup (details on issue #287). Post this to the container to ensure the attach is complete before we try to remove
             // anything.
+            if (to != null) {
+                to.setNeedsAttach(true);
+            }
             pendingControllerChanges.add(transaction);
             container.post(new Runnable() {
                 @Override

--- a/conductor/src/test/java/com/bluelinelabs/conductor/ReattachCaseTests.java
+++ b/conductor/src/test/java/com/bluelinelabs/conductor/ReattachCaseTests.java
@@ -3,7 +3,9 @@ package com.bluelinelabs.conductor;
 import android.os.Bundle;
 import android.view.ViewGroup;
 
+import com.bluelinelabs.conductor.internal.LifecycleHandler;
 import com.bluelinelabs.conductor.util.ActivityProxy;
+import com.bluelinelabs.conductor.util.AttachFakingFrameLayout;
 import com.bluelinelabs.conductor.util.MockChangeHandler;
 import com.bluelinelabs.conductor.util.TestController;
 import com.bluelinelabs.conductor.util.ViewUtils;
@@ -285,6 +287,68 @@ public class ReattachCaseTests {
         assertTrue(controller1.isAttached());
         assertFalse(controller2.isAttached());
         assertTrue(controller3.isAttached());
+    }
+
+    @Test
+    public void testPendingChanges() {
+        Controller controller1 = new TestController();
+        Controller controller2 = new TestController();
+
+        ActivityProxy activityProxy = new ActivityProxy().create(null);
+        AttachFakingFrameLayout container = new AttachFakingFrameLayout(activityProxy.getActivity());
+        container.setId(5);
+        container.setNeedDelayPost(true); // to simulate calling posts after resume
+
+        activityProxy.setView(container);
+
+        Router router = Conductor.attachRouter(activityProxy.getActivity(), container, null);
+        router.setRoot(RouterTransaction.with(controller1));
+        router.pushController(RouterTransaction.with(controller2));
+
+        activityProxy.start().resume();
+        container.setNeedDelayPost(false);
+
+        assertTrue(controller2.isAttached());
+    }
+
+    @Test
+    public void testPendingChangesAfterRotation() {
+        Controller controller1 = new TestController();
+        Controller controller2 = new TestController();
+
+        // first activity
+        ActivityProxy activityProxy = new ActivityProxy().create(null);
+        AttachFakingFrameLayout container1 = new AttachFakingFrameLayout(activityProxy.getActivity());
+
+        container1.setNeedDelayPost(true); // delay forever as view will be removed
+        activityProxy.setView(container1);
+
+        // first attachRouter: Conductor.attachRouter(activityProxy.getActivity(), container1, null)
+        LifecycleHandler lifecycleHandler = LifecycleHandler.install(activityProxy.getActivity());
+        Router router = lifecycleHandler.getRouter(container1, null);
+        router.setRoot(RouterTransaction.with(controller1));
+
+        // setup controllers
+        router.pushController(RouterTransaction.with(controller2));
+
+        // simulate setRequestedOrientation in activity onCreate
+        activityProxy.start().resume();
+        Bundle savedState = new Bundle();
+        activityProxy.saveInstanceState(savedState).pause().stop(true);
+
+        // recreate activity and view
+        activityProxy = new ActivityProxy().create(savedState);
+        AttachFakingFrameLayout container2 = new AttachFakingFrameLayout(activityProxy.getActivity());
+        activityProxy.setView(container2);
+
+        // second attach router with the same lifecycleHandler (do manually as Roboelectric recreates retained fragments)
+        // Conductor.attachRouter(activityProxy.getActivity(), container2, savedState);
+        router = lifecycleHandler.getRouter(container2, savedState);
+        router.rebindIfNeeded();
+
+        activityProxy.start().resume();
+
+        assertTrue(controller2.isAttached());
     }
 
     private void sleepWakeDevice() {

--- a/conductor/src/test/java/com/bluelinelabs/conductor/ReattachCaseTests.java
+++ b/conductor/src/test/java/com/bluelinelabs/conductor/ReattachCaseTests.java
@@ -296,7 +296,6 @@ public class ReattachCaseTests {
 
         ActivityProxy activityProxy = new ActivityProxy().create(null);
         AttachFakingFrameLayout container = new AttachFakingFrameLayout(activityProxy.getActivity());
-        container.setId(5);
         container.setNeedDelayPost(true); // to simulate calling posts after resume
 
         activityProxy.setView(container);

--- a/conductor/src/test/java/com/bluelinelabs/conductor/util/ActivityProxy.java
+++ b/conductor/src/test/java/com/bluelinelabs/conductor/util/ActivityProxy.java
@@ -7,6 +7,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 
 public class ActivityProxy {
+    private final @IdRes int containerId = 4;
 
     private ActivityController<TestActivity> activityController;
     private AttachFakingFrameLayout view;
@@ -14,8 +15,12 @@ public class ActivityProxy {
     public ActivityProxy() {
         activityController = Robolectric.buildActivity(TestActivity.class);
 
-        @IdRes int containerId = 4;
         view = new AttachFakingFrameLayout(activityController.get());
+        view.setId(containerId);
+    }
+
+    public void setView(AttachFakingFrameLayout view) {
+        this.view = view;
         view.setId(containerId);
     }
 

--- a/conductor/src/test/java/com/bluelinelabs/conductor/util/AttachFakingFrameLayout.java
+++ b/conductor/src/test/java/com/bluelinelabs/conductor/util/AttachFakingFrameLayout.java
@@ -10,6 +10,8 @@ import android.view.View;
 import android.widget.FrameLayout;
 
 import java.io.FileDescriptor;
+import java.util.ArrayList;
+import java.util.List;
 
 public class AttachFakingFrameLayout extends FrameLayout {
 
@@ -62,6 +64,9 @@ public class AttachFakingFrameLayout extends FrameLayout {
 
     private boolean reportAttached;
 
+    private boolean needDelayPost;
+    private List<Runnable> delayedPosts = new ArrayList<>();
+
     public AttachFakingFrameLayout(Context context) {
         super(context);
     }
@@ -110,4 +115,34 @@ public class AttachFakingFrameLayout extends FrameLayout {
         super.onViewRemoved(child);
     }
 
+    @Override
+    public boolean post(Runnable action) {
+        if (needDelayPost) {
+            delayedPosts.add(action);
+        } else {
+            return super.post(action);
+        }
+
+        return true;
+    }
+
+    public void runDelayedPosts() {
+        for (Runnable runnable : delayedPosts) {
+            runnable.run();
+        }
+
+        clearDelayedPosts();
+    }
+
+    public void clearDelayedPosts() {
+        delayedPosts.clear();
+    }
+
+    public void setNeedDelayPost(boolean needDelayPost) {
+        this.needDelayPost = needDelayPost;
+
+        if (!this.needDelayPost && delayedPosts.size() > 0) {
+            runDelayedPosts();
+        }
+    }
 }


### PR DESCRIPTION
According my comment in https://github.com/bluelinelabs/Conductor/issues/287 here I've fixed locking all changes to a router because of having constantly non empty pendingControllerChanges after rotation on launching.

That can be reproduced after adding this lines in the demo activity and launching app in a rotated simulator: https://github.com/soniccat/Conductor/commit/a86d0c6428e6bed412dc46b2e7d720d7d7d204e9