### PR TITLE
Fixed having a not attached child controller after popping back to the parent

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
@@ -922,6 +922,8 @@ public abstract class Controller {
                     childTransaction.controller.attach(childTransaction.controller.view);
                 }
             }
+
+            childRouter.rebindIfNeeded();
         }
     }
 
@@ -1295,7 +1297,11 @@ public abstract class Controller {
             }
 
             if (!frozen && view != null && viewWasDetached) {
+                View aView = view;
                 detach(view, false, false);
+                if (view == null && aView.getParent() == router.container) {
+                    router.container.removeView(aView); // need to remove the view when this controller is a child controller
+                }
             }
         }
     }

--- a/conductor/src/test/java/com/bluelinelabs/conductor/ControllerLifecycleCallbacksTests.java
+++ b/conductor/src/test/java/com/bluelinelabs/conductor/ControllerLifecycleCallbacksTests.java
@@ -535,6 +535,29 @@ public class ControllerLifecycleCallbacksTests {
         assertTrue(child.isAttached());
     }
 
+    @Test
+    public void testChildLifecycleAfterPushAndPop() {
+        Controller parent = new TestController();
+        parent.setRetainViewMode(RetainViewMode.RETAIN_DETACH);
+        router.pushController(RouterTransaction.with(parent)
+                .pushChangeHandler(MockChangeHandler.defaultHandler())
+                .popChangeHandler(MockChangeHandler.defaultHandler()));
+
+        TestController child = new TestController();
+        Router childRouter = parent.getChildRouter((ViewGroup)parent.getView().findViewById(TestController.VIEW_ID));
+        childRouter
+                .setRoot(RouterTransaction.with(child)
+                        .pushChangeHandler(new SimpleSwapChangeHandler())
+                        .popChangeHandler(new SimpleSwapChangeHandler()));
+
+        Controller nextController = new TestController();
+        router.pushController(RouterTransaction.with(nextController));
+        router.popCurrentController();
+
+        assertTrue(parent.isAttached());
+        assertTrue(child.isAttached());
+    }
+
     private MockChangeHandler getPushHandler(final CallState expectedCallState, final TestController controller) {
         return MockChangeHandler.listeningChangeHandler(new ChangeHandlerListener() {
             @Override


### PR DESCRIPTION
Came across a bug when we have a parent controller with RETAIN_DETACH and its child controller with RELEASE_DETACH. If we push another RELEASE_DETACH controller to the parent router and then pop back, the child controller won't be attached and it will have a null view property but the view itself will be still in its parent and therefore visible... Here I've fixed the bug and added a correspond test.

The current workaround for this bug is setting RETAIN_DETACH for the child controller.