### PR TITLE
Migrated to AndroidX Fragments

### DIFF
--- a/conductor-modules/viewpager/build.gradle
+++ b/conductor-modules/viewpager/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
+    testOptions.unitTests.includeAndroidResources = true
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion

--- a/conductor-modules/viewpager/src/test/java/com/bluelinelabs/conductor/viewpager/StateSaveTests.kt
+++ b/conductor-modules/viewpager/src/test/java/com/bluelinelabs/conductor/viewpager/StateSaveTests.kt
@@ -1,7 +1,7 @@
 package com.bluelinelabs.conductor.viewpager
 
-import android.app.Activity
 import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import com.bluelinelabs.conductor.Conductor
 import com.bluelinelabs.conductor.Router
@@ -23,7 +23,10 @@ class StateSaveTests {
   private val pagerAdapter: RouterPagerAdapter
 
   init {
-    val activityController = Robolectric.buildActivity(Activity::class.java).setup()
+    val activityController = Robolectric.buildActivity(AppCompatActivity::class.java)
+    activityController.get().setTheme(R.style.Theme_AppCompat)
+    activityController.setup()
+
     val router = Conductor.attachRouter(activityController.get(), FrameLayout(activityController.get()), null)
     val controller = TestController()
     router.setRoot(with(controller))

--- a/conductor/build.gradle
+++ b/conductor/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
+    testOptions.unitTests.includeAndroidResources = true
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
@@ -17,7 +18,9 @@ dependencies {
     testImplementation rootProject.ext.junit
     testImplementation rootProject.ext.roboelectric
 
+    api rootProject.ext.androidxAppCompat
     api rootProject.ext.androidxAnnotations
+    api rootProject.ext.androidxFragment
     api kotlinStd
 
     lintPublish project(':conductor-lint')

--- a/conductor/src/main/java/com/bluelinelabs/conductor/ActivityHostedRouter.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/ActivityHostedRouter.java
@@ -64,8 +64,8 @@ public class ActivityHostedRouter extends Router {
 
     @Override
     public final void invalidateOptionsMenu() {
-        if (lifecycleHandler != null && lifecycleHandler.getFragmentManager() != null) {
-            lifecycleHandler.getFragmentManager().invalidateOptionsMenu();
+        if (lifecycleHandler != null && lifecycleHandler.getLifecycleActivity() != null) {
+            lifecycleHandler.getLifecycleActivity().invalidateOptionsMenu();
         }
     }
 

--- a/conductor/src/main/java/com/bluelinelabs/conductor/Conductor.kt
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Conductor.kt
@@ -1,9 +1,9 @@
 package com.bluelinelabs.conductor
 
-import android.app.Activity
 import android.os.Bundle
 import android.view.ViewGroup
 import androidx.annotation.UiThread
+import androidx.fragment.app.FragmentActivity
 import com.bluelinelabs.conductor.internal.LifecycleHandler
 import com.bluelinelabs.conductor.internal.ensureMainThread
 
@@ -23,7 +23,7 @@ import com.bluelinelabs.conductor.internal.ensureMainThread
 object Conductor {
   
   @JvmStatic
-  fun attachRouter(activity: Activity, container: ViewGroup, savedInstanceState: Bundle?): Router {
+  fun attachRouter(activity: FragmentActivity, container: ViewGroup, savedInstanceState: Bundle?): Router {
     ensureMainThread()
     return LifecycleHandler.install(activity)
       .getRouter(container, savedInstanceState)

--- a/conductor/src/main/java/com/bluelinelabs/conductor/internal/LifecycleHandler.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/internal/LifecycleHandler.java
@@ -3,7 +3,6 @@ package com.bluelinelabs.conductor.internal;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Application.ActivityLifecycleCallbacks;
-import android.app.Fragment;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
@@ -19,6 +18,8 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 
 import com.bluelinelabs.conductor.ActivityHostedRouter;
 import com.bluelinelabs.conductor.Router;
@@ -37,13 +38,13 @@ public class LifecycleHandler extends Fragment implements ActivityLifecycleCallb
     private static final String KEY_ACTIVITY_REQUEST_CODES = "LifecycleHandler.activityRequests";
     private static final String KEY_ROUTER_STATE_PREFIX = "LifecycleHandler.routerState";
 
-    private Activity activity;
+    private FragmentActivity activity;
     private boolean hasRegisteredCallbacks;
     private boolean destroyed;
     private boolean attached;
     private boolean hasPreparedForHostDetach;
 
-    private static final Map<Activity, LifecycleHandler> activeLifecycleHandlers = new HashMap<>();
+    private static final Map<FragmentActivity, LifecycleHandler> activeLifecycleHandlers = new HashMap<>();
     private SparseArray<String> permissionRequestMap = new SparseArray<>();
     private SparseArray<String> activityRequestMap = new SparseArray<>();
     private ArrayList<PendingPermissionRequest> pendingPermissionRequests = new ArrayList<>();
@@ -56,10 +57,10 @@ public class LifecycleHandler extends Fragment implements ActivityLifecycleCallb
     }
 
     @Nullable
-    private static LifecycleHandler findInActivity(@NonNull Activity activity) {
+    private static LifecycleHandler findInActivity(@NonNull FragmentActivity activity) {
         LifecycleHandler lifecycleHandler = activeLifecycleHandlers.get(activity);
         if (lifecycleHandler == null) {
-            lifecycleHandler = (LifecycleHandler)activity.getFragmentManager().findFragmentByTag(FRAGMENT_TAG);
+            lifecycleHandler = (LifecycleHandler)activity.getSupportFragmentManager().findFragmentByTag(FRAGMENT_TAG);
         }
         if (lifecycleHandler != null) {
             lifecycleHandler.registerActivityListener(activity);
@@ -68,11 +69,11 @@ public class LifecycleHandler extends Fragment implements ActivityLifecycleCallb
     }
 
     @NonNull
-    public static LifecycleHandler install(@NonNull Activity activity) {
+    public static LifecycleHandler install(@NonNull FragmentActivity activity) {
         LifecycleHandler lifecycleHandler = findInActivity(activity);
         if (lifecycleHandler == null) {
             lifecycleHandler = new LifecycleHandler();
-            activity.getFragmentManager().beginTransaction().add(lifecycleHandler, FRAGMENT_TAG).commit();
+            activity.getSupportFragmentManager().beginTransaction().add(lifecycleHandler, FRAGMENT_TAG).commit();
         }
         lifecycleHandler.registerActivityListener(activity);
         return lifecycleHandler;
@@ -113,7 +114,7 @@ public class LifecycleHandler extends Fragment implements ActivityLifecycleCallb
         return viewGroup.getId();
     }
 
-    private void registerActivityListener(@NonNull Activity activity) {
+    private void registerActivityListener(@NonNull FragmentActivity activity) {
         this.activity = activity;
 
         if (!hasRegisteredCallbacks) {
@@ -319,8 +320,8 @@ public class LifecycleHandler extends Fragment implements ActivityLifecycleCallb
 
     @Override
     public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-        if (this.activity == null && findInActivity(activity) == LifecycleHandler.this) {
-            this.activity = activity;
+        if (this.activity == null && activity instanceof FragmentActivity && findInActivity((FragmentActivity) activity) == LifecycleHandler.this) {
+            this.activity = (FragmentActivity) activity;
 
             for (ActivityHostedRouter router : new ArrayList<>(routerMap.values())) {
                 router.onContextAvailable();

--- a/conductor/src/test/java/com/bluelinelabs/conductor/BackstackTests.java
+++ b/conductor/src/test/java/com/bluelinelabs/conductor/BackstackTests.java
@@ -4,9 +4,12 @@ import com.bluelinelabs.conductor.util.TestController;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(RobolectricTestRunner.class)
 public class BackstackTests {
 
     private Backstack backstack;

--- a/conductor/src/test/java/com/bluelinelabs/conductor/util/ActivityProxy.kt
+++ b/conductor/src/test/java/com/bluelinelabs/conductor/util/ActivityProxy.kt
@@ -4,13 +4,16 @@ import android.content.pm.ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
 import android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
 import android.os.Bundle
 import androidx.annotation.IdRes
+import com.bluelinelabs.conductor.R
 import org.robolectric.Robolectric
 
 class ActivityProxy {
 
   @IdRes
   private val containerId = 4
-  private val activityController = Robolectric.buildActivity(TestActivity::class.java)
+  private val activityController = Robolectric.buildActivity(TestActivity::class.java).apply {
+    get().setTheme(R.style.Theme_AppCompat)
+  }
 
   val activity: TestActivity
     get() = activityController.get()

--- a/conductor/src/test/java/com/bluelinelabs/conductor/util/TestActivity.java
+++ b/conductor/src/test/java/com/bluelinelabs/conductor/util/TestActivity.java
@@ -1,8 +1,8 @@
 package com.bluelinelabs.conductor.util;
 
-import android.app.Activity;
+import androidx.appcompat.app.AppCompatActivity;
 
-public class TestActivity extends Activity {
+public class TestActivity extends AppCompatActivity {
 
     public boolean isChangingConfigurations = false;
     public boolean isDestroying = false;

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -24,6 +24,7 @@ ext {
     androidxAppCompat = "androidx.appcompat:appcompat:1.0.0"
     androidxTransition = "androidx.transition:transition:1.3.1"
     androidxCollection = "androidx.collection:collection:1.1.0"
+    androidxFragment = "androidx.fragment:fragment:1.2.4"
 
     butterknife = "com.jakewharton:butterknife:$butterknifeVersion"
     butterknifeCompiler = "com.jakewharton:butterknife-compiler:$butterknifeVersion"


### PR DESCRIPTION
Motivation:
1) android.app.Fragment is deprecated;
2) Consistent behavior across different api versions;
3) I use Conductor in my project and noticed probably unexpected behavior when working with runtime permissions. With androidx.Fragment or AppCompatActivity if you try to start another one request with the same id, previous request will be automatically cancelled by Android. But android.app.Fragment does not do this (at least on Android 7 and 8), it invokes onRequestPermissionsResult() method twice.