### PR TITLE
Fixes issues in Router.pushController, Router.popController & Router.setBackstack where pushChangeHandler().removesFromViewOnPush() was not respected

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/Router.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Router.java
@@ -135,7 +135,22 @@ public abstract class Router {
 
         if (poppingTopController) {
             trackDestroyingController(backstack.pop());
-            performControllerChange(backstack.peek(), topTransaction, false);
+            // Ensure all entries on the backstack, which should be visible, becomes so
+            List<RouterTransaction> newVisibleTransactions = getVisibleTransactions(backstack.iterator(), false);
+            if (newVisibleTransactions.isEmpty()) {
+                // Nothing else is visible, so just pop
+                performControllerChange(backstack.peek(), topTransaction, false);
+            } else {
+                // Loop backwards to ensure the last change made is the new top Controller
+                for (int i = newVisibleTransactions.size() - 1; i >= 0; i--) {
+                    RouterTransaction newVisibleTransaction = newVisibleTransactions.get(i);
+                    if (i == 0) {
+                        performControllerChange(newVisibleTransaction, topTransaction, false, topTransaction.popChangeHandler());
+                    } else {
+                        performControllerChange(newVisibleTransaction, null, false, topTransaction.popChangeHandler());
+                    }
+                }
+            }
         } else {
             RouterTransaction removedTransaction = null;
             RouterTransaction nextTransaction = null;
@@ -179,8 +194,12 @@ public abstract class Router {
     public void pushController(@NonNull RouterTransaction transaction) {
         ThreadUtils.ensureMainThread();
 
+        List<RouterTransaction> oldVisibleTransactions = getVisibleTransactions(backstack.iterator(), false);
         RouterTransaction from = backstack.peek();
         pushToBackstack(transaction);
+
+        ensureRemovesFromViewOnPushRemovalIsEnforced(transaction, from, oldVisibleTransactions, null);
+
         performControllerChange(transaction, from, true);
     }
 
@@ -201,16 +220,7 @@ public abstract class Router {
         }
 
         final ControllerChangeHandler handler = transaction.pushChangeHandler();
-        if (topTransaction != null) {
-            //noinspection ConstantConditions
-            final boolean oldHandlerRemovedViews = topTransaction.pushChangeHandler() == null || topTransaction.pushChangeHandler().removesFromViewOnPush();
-            final boolean newHandlerRemovesViews = handler == null || handler.removesFromViewOnPush();
-            if (!oldHandlerRemovedViews && newHandlerRemovesViews) {
-                for (RouterTransaction visibleTransaction : getVisibleTransactions(backstack.iterator(), true)) {
-                    performControllerChange(null, visibleTransaction, true, handler);
-                }
-            }
-        }
+        ensureRemovesFromViewOnPushRemovalIsEnforced(transaction, topTransaction, getVisibleTransactions(backstack.iterator(), true), handler);
 
         pushToBackstack(transaction);
 
@@ -931,6 +941,33 @@ public abstract class Router {
         }
     }
 
+    /**
+     * Goes through all {@param oldVisibleTransactions} to ensure {@link ControllerChangeHandler#removesFromViewOnPush()} == false
+     * is only respected if the preceding {@link Controller} is also visible. Detaches all {@link Controller}s who are no longer supposed to be attached.
+     *
+     * @param newTopTransaction      The transaction intended to be the new top
+     * @param oldTopTransaction      The transaction which was previously the top, if any
+     * @param oldVisibleTransactions All transactions which were previously deemed visible as per {@link Router#getVisibleTransactions(Iterator, boolean)}
+     * @param changeHandler          Optional {@link ControllerChangeHandler} to override transition when removing any {@link Controller}s deemed to require removal
+     */
+    private void ensureRemovesFromViewOnPushRemovalIsEnforced(
+            @NonNull RouterTransaction newTopTransaction,
+            @Nullable RouterTransaction oldTopTransaction,
+            @NonNull List<RouterTransaction> oldVisibleTransactions,
+            @Nullable ControllerChangeHandler changeHandler) {
+        if (oldTopTransaction != null) {
+            final ControllerChangeHandler newChangeHandler = newTopTransaction.pushChangeHandler() != null ? newTopTransaction.pushChangeHandler() : changeHandler;
+            //noinspection ConstantConditions
+            final boolean oldHandlerRemovedViews = oldTopTransaction.pushChangeHandler() == null || oldTopTransaction.pushChangeHandler().removesFromViewOnPush();
+            final boolean newHandlerRemovesViews = newChangeHandler == null || newChangeHandler.removesFromViewOnPush();
+            if (!oldHandlerRemovedViews && newHandlerRemovesViews) {
+                for (RouterTransaction visibleTransaction : oldVisibleTransactions) {
+                    performControllerChange(null, visibleTransaction, false);
+                }
+            }
+        }
+    }
+
     // Swap around transaction indices to ensure they don't get thrown out of order by the
     // developer rearranging the backstack at runtime.
     private void ensureOrderedTransactionIndices(List<RouterTransaction> backstack) {
@@ -981,7 +1018,9 @@ public abstract class Router {
                 transactions.add(transaction);
             }
 
-            visible = transaction.pushChangeHandler() != null && !transaction.pushChangeHandler().removesFromViewOnPush();
+            // We only care about removesFromViewOnPush if the current transaction is visible
+            //noinspection ConstantConditions
+            visible = visible && transaction.pushChangeHandler() != null && !transaction.pushChangeHandler().removesFromViewOnPush();
 
             if (onlyTop && !visible) {
                 break;

--- a/conductor/src/test/java/com/bluelinelabs/conductor/RouterTests.kt
+++ b/conductor/src/test/java/com/bluelinelabs/conductor/RouterTests.kt
@@ -252,6 +252,103 @@ class RouterTests {
   }
 
   @Test
+  fun testPushThenPopWithSetBackstackWithNoRemoveViewOnPush() {
+    val oldRootTransaction = TestController().asTransaction()
+    val oldTopTransaction = TestController().asTransaction(
+      pushChangeHandler = MockChangeHandler.noRemoveViewOnPushHandler()
+    )
+    router.setRoot(oldRootTransaction)
+    router.pushController(oldTopTransaction)
+    Assert.assertEquals(2, router.backstackSize.toLong())
+    Assert.assertTrue(oldRootTransaction.controller.isAttached)
+    Assert.assertTrue(oldTopTransaction.controller.isAttached)
+
+    val newTopTransaction = TestController().asTransaction()
+    router.pushController(newTopTransaction)
+
+    Assert.assertEquals(3, router.backstackSize.toLong())
+    Assert.assertFalse(oldRootTransaction.controller.isAttached)
+    Assert.assertFalse(oldTopTransaction.controller.isAttached)
+    Assert.assertTrue(newTopTransaction.controller.isAttached)
+
+    val backstack2 = listOf(oldRootTransaction, oldTopTransaction)
+    router.setBackstack(backstack2, null)
+
+    Assert.assertEquals(2, router.backstackSize.toLong())
+    val fetchedBackstack = router.getBackstack()
+    Assert.assertEquals(oldRootTransaction, fetchedBackstack[0])
+    Assert.assertEquals(oldTopTransaction, fetchedBackstack[1])
+    Assert.assertTrue(oldRootTransaction.controller.isAttached)
+    Assert.assertTrue(oldTopTransaction.controller.isAttached)
+    Assert.assertFalse(newTopTransaction.controller.isAttached)
+  }
+
+  @Test
+  fun testPopUsingSetBackstackWithNoRemoveViewOnPush() {
+    val oldRootTransaction = TestController().asTransaction()
+    val oldTopTransaction = TestController().asTransaction(
+      pushChangeHandler = MockChangeHandler.noRemoveViewOnPushHandler()
+    )
+    router.setRoot(oldRootTransaction)
+    router.pushController(oldTopTransaction)
+    Assert.assertEquals(2, router.backstackSize.toLong())
+    Assert.assertTrue(oldRootTransaction.controller.isAttached)
+    Assert.assertTrue(oldTopTransaction.controller.isAttached)
+
+    val newTopTransaction = TestController().asTransaction()
+    val backstack = listOf(oldRootTransaction, oldTopTransaction, newTopTransaction)
+    router.setBackstack(backstack, null)
+
+    Assert.assertEquals(3, router.backstackSize.toLong())
+    Assert.assertFalse(oldRootTransaction.controller.isAttached)
+    Assert.assertFalse(oldTopTransaction.controller.isAttached)
+    Assert.assertTrue(newTopTransaction.controller.isAttached)
+
+    val backstack2 = listOf(oldRootTransaction, oldTopTransaction)
+    router.setBackstack(backstack2, null)
+
+    Assert.assertEquals(2, router.backstackSize.toLong())
+    val fetchedBackstack = router.getBackstack()
+    Assert.assertEquals(oldRootTransaction, fetchedBackstack[0])
+    Assert.assertEquals(oldTopTransaction, fetchedBackstack[1])
+    Assert.assertTrue(oldRootTransaction.controller.isAttached)
+    Assert.assertTrue(oldTopTransaction.controller.isAttached)
+    Assert.assertFalse(newTopTransaction.controller.isAttached)
+  }
+
+  @Test
+  fun testPopWithNoRemoveViewOnPush() {
+    val oldRootTransaction = TestController().asTransaction()
+    val oldTopTransaction = TestController().asTransaction(
+      pushChangeHandler = MockChangeHandler.noRemoveViewOnPushHandler()
+    )
+    router.setRoot(oldRootTransaction)
+    router.pushController(oldTopTransaction)
+    Assert.assertEquals(2, router.backstackSize.toLong())
+    Assert.assertTrue(oldRootTransaction.controller.isAttached)
+    Assert.assertTrue(oldTopTransaction.controller.isAttached)
+
+    val newTopTransaction = TestController().asTransaction()
+    val backstack = listOf(oldRootTransaction, oldTopTransaction, newTopTransaction)
+    router.setBackstack(backstack, null)
+
+    Assert.assertEquals(3, router.backstackSize.toLong())
+    Assert.assertFalse(oldRootTransaction.controller.isAttached)
+    Assert.assertFalse(oldTopTransaction.controller.isAttached)
+    Assert.assertTrue(newTopTransaction.controller.isAttached)
+
+    router.popCurrentController()
+
+    Assert.assertEquals(2, router.backstackSize.toLong())
+    val fetchedBackstack = router.getBackstack()
+    Assert.assertEquals(oldRootTransaction, fetchedBackstack[0])
+    Assert.assertEquals(oldTopTransaction, fetchedBackstack[1])
+    Assert.assertTrue(oldRootTransaction.controller.isAttached)
+    Assert.assertTrue(oldTopTransaction.controller.isAttached)
+    Assert.assertFalse(newTopTransaction.controller.isAttached)
+  }
+
+  @Test
   fun testPopToRoot() {
     val rootTransaction = TestController().asTransaction()
     val transaction1 = TestController().asTransaction()

--- a/conductor/src/test/java/com/bluelinelabs/conductor/ViewLeakTests.kt
+++ b/conductor/src/test/java/com/bluelinelabs/conductor/ViewLeakTests.kt
@@ -105,7 +105,7 @@ class ViewLeakTests {
 
     router.pushController(TestController().asTransaction())
     shadowOf(Looper.getMainLooper()).idle()
-    Assert.assertNotNull(view.parent)
+    Assert.assertNull(view.parent)
 
     router.popToRoot()
     shadowOf(Looper.getMainLooper()).idle()

--- a/demo/src/main/java/com/bluelinelabs/conductor/demo/controllers/DialogController.kt
+++ b/demo/src/main/java/com/bluelinelabs/conductor/demo/controllers/DialogController.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.text.method.LinkMovementMethod
 import android.view.View
 import androidx.core.os.bundleOf
+import com.bluelinelabs.conductor.RouterTransaction
+import com.bluelinelabs.conductor.changehandler.HorizontalChangeHandler
 import com.bluelinelabs.conductor.demo.R
 import com.bluelinelabs.conductor.demo.controllers.base.BaseController
 import com.bluelinelabs.conductor.demo.databinding.ControllerDialogBinding
@@ -23,7 +25,21 @@ class DialogController(args: Bundle) : BaseController(R.layout.controller_dialog
     binding.title.text = args.getCharSequence(KEY_TITLE)
     binding.description.text = args.getCharSequence(KEY_DESCRIPTION)
     binding.description.movementMethod = LinkMovementMethod.getInstance()
-
+    binding.next.setOnClickListener {
+      val backstack = router.backstack.plus(
+        RouterTransaction.with(TextController("Came here via setBackstack - Now test back button!"))
+          .pushChangeHandler(HorizontalChangeHandler())
+          .popChangeHandler(HorizontalChangeHandler())
+      )
+      router.setBackstack(backstack, backstack.last().pushChangeHandler())
+    }
+    binding.nextPush.setOnClickListener {
+      router.pushController(
+        RouterTransaction.with(TextController("Came here via pushController - Now test back button!"))
+          .pushChangeHandler(HorizontalChangeHandler())
+          .popChangeHandler(HorizontalChangeHandler())
+      )
+    }
     binding.dismiss.setOnClickListener { router.popController(this) }
     binding.dialogBackground.setOnClickListener { router.popController(this) }
   }

--- a/demo/src/main/res/layout/controller_dialog.xml
+++ b/demo/src/main/res/layout/controller_dialog.xml
@@ -47,6 +47,36 @@
             />
 
         <Button
+            android:id="@+id/next"
+            style="@style/Widget.AppCompat.Button.Borderless.Colored"
+            android:layout_width="wrap_content"
+            android:layout_height="36dp"
+            android:layout_gravity="end|bottom"
+            android:layout_marginBottom="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginRight="8dp"
+            android:layout_marginTop="8dp"
+            android:minWidth="64dp"
+            android:text="@string/next"
+            />
+
+        <Button
+            android:id="@+id/nextPush"
+            style="@style/Widget.AppCompat.Button.Borderless.Colored"
+            android:layout_width="wrap_content"
+            android:layout_height="36dp"
+            android:layout_gravity="end|bottom"
+            android:layout_marginBottom="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginRight="8dp"
+            android:layout_marginTop="8dp"
+            android:minWidth="64dp"
+            android:text="@string/next_controller"
+            />
+
+        <Button
             android:id="@+id/dismiss"
             style="@style/Widget.AppCompat.Button.Borderless.Colored"
             android:layout_width="wrap_content"


### PR DESCRIPTION

_Motivation:_
I encountered these issues while migrating existing code to androidX Navigation, and thus creating a `ControllerNavigator` along with others to support coexisting `FragmentDialogs/Controllers` with the hope of being able to just plug in `Fragments` (if the need ever arises) or hopefully `Compose` when its more mature and time permits.

_Issue:_
During this pursuit, I started leveraging `Router.setBackstack` for all changes to the `Router.backstack`, and in my test app I had a flow that looked like this:
`AboutController -> DialogController (with pushChangeHandler().removesFromViewOnPush() = false) -> DetailsController`

When pressing back while on `DetailsController`, the `DialogController` would re-appear, but without `AboutController` being visible underneath. During debugging I found that `AboutController` was not properly detached, even though its view was removed during the transition from `DialogController -> DetailsController.`

Another issue that would manifest is if we take the following backstack:
`AboutController -> DialogController (with pushChangeHandler().removesFromViewOnPush() = false) -> DetailsAController -> DetailsBController`
When pressing back while on `DetailsBController`, the transitions would not be as expected, since it would first transition `from(DetailsBController) to(null)`, and then `from(null) to(DetailsAController)`, rather than the expected `from(DetailsBController) to(DetailsAController)`.

While I suppose not popping a dialog when navigating away from it, is atypical behaviour, I see no reason why it shouldn't be supported. A concrete use case in the app I'm working on is showing a dialog to select Time and then the option to open another dialog to select Date.

_The Fix:_
I added three test cases to `RouterTests` which proved the issue prior to my fix, during which I discovered that `pushController` shared the same issue as `setBackstack`, and that `popController` would not properly attach all views. I also updated the demo app to have let the `DialogController` navigate to another `Controller`, to trigger some of this behaviour and verify transitions looked as expected. I realise that this code may not be something you'd want in the repo, but I thought I'd leave it in a separate commit, for your testing convenience - and for ease of removal if need be.

Inspired by how `replaceTopController` worked, I used that, along with ensuring that `getVisibleTransactions` would no longer incorrectly assume that any transaction prior to a `removesFromViewOnPush=false` transaction, is visible.

Perhaps there are other cases which I didn't think to trigger, so hopefully whoever reviews this has more intimate knowledge of the inner `Router` workings, and can have a think as to whether there are other cases, or whether it would be better to change `performControllerChange` to handle some of these fixes too.
The issues seem related to #608, since both are about `removesFromViewOnPush` when manipulating the backstack, but I also noticed that `ViewLeakTests.testViewRemovedIfLayeredNotRemovesFromViewOnPush` was making the assumption that the `Controller` which comes before the one with `removesFromViewOnPush=false` remains attached even when pushing a new `Controller` with `removesFromViewOnPush=true` on top - which to me was the whole issue.

Thanks for many years of Conductor-awesomeness, I've truly been happy using it, just as I am happy to be able to contribute meaningfully (as you hopefully agree with! :) )
/Christian


Some brief video recordings of two issues before and after my fix:

https://user-images.githubusercontent.com/62065253/153869081-c0481500-b986-4305-8a13-aa187c8b0c5a.mp4


https://user-images.githubusercontent.com/62065253/153869095-e52bf9ca-0990-4f24-a548-194a98fc332c.mp4


https://user-images.githubusercontent.com/62065253/153869101-cd7aa9de-7b69-4b25-bcad-5cb928fe36f8.mp4


https://user-images.githubusercontent.com/62065253/153869099-3642f40b-153b-47cf-9b11-e4bab9032202.mp4
