### PR TITLE
Fix issue where child controllers may not get their onPause event soon enough

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/internal/OwnViewTreeLifecycleAndRegistry.kt
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/internal/OwnViewTreeLifecycleAndRegistry.kt
@@ -1,5 +1,6 @@
 package com.bluelinelabs.conductor.internal
 
+import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.Lifecycle
@@ -28,6 +29,7 @@ internal class OwnViewTreeLifecycleAndRegistry private constructor(
 
   private var hasSavedState = false
   private var savedRegistryState = Bundle.EMPTY
+  private val parentChangeListeners = mutableMapOf<String, Controller.LifecycleListener>()
 
   init {
     controller.addLifecycleListener(object : Controller.LifecycleListener() {
@@ -84,29 +86,17 @@ internal class OwnViewTreeLifecycleAndRegistry private constructor(
         }
       }
 
-      // AbstractComposeView adds its own OnAttachStateChangeListener by default. Since it
-      // does this on init, its detach callbacks get called before ours, which prevents us
-      // from saving state in onDetach. The if statement in here should detect upcoming
-      // detachment.
       override fun onChangeStart(
         changeController: Controller,
         changeHandler: ControllerChangeHandler,
-        changeType: ControllerChangeType
+        changeType: ControllerChangeType,
       ) {
-        if (
-          controller === changeController &&
-          !changeType.isEnter &&
-          changeHandler.removesFromViewOnPush() &&
-          changeController.view != null &&
-          lifecycleRegistry.currentState == Lifecycle.State.RESUMED
-        ) {
-          lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
-
-          savedRegistryState = Bundle()
-          savedStateRegistryController.performSave(savedRegistryState)
-
-          hasSavedState = true
-        }
+        pauseOnChangeStart(
+          targetController = controller,
+          changeController = changeController,
+          changeHandler = changeHandler,
+          changeType = changeType,
+        )
       }
 
       override fun preDetach(controller: Controller, view: View) {
@@ -147,12 +137,78 @@ internal class OwnViewTreeLifecycleAndRegistry private constructor(
           lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
         }
       }
+
+      override fun postContextAvailable(controller: Controller, context: Context) {
+        listenForParentChangeStart(controller)
+      }
+
+      override fun preContextUnavailable(controller: Controller, context: Context) {
+        stopListeningForParentChangeStart(controller)
+      }
     })
   }
 
   override fun getLifecycle() = lifecycleRegistry
 
   override fun getSavedStateRegistry() = savedStateRegistryController.savedStateRegistry
+
+  private fun listenForParentChangeStart(controller: Controller) {
+    controller.parentController?.let { parent ->
+      val changeListener = object : Controller.LifecycleListener() {
+        override fun onChangeStart(
+          controller: Controller,
+          changeHandler: ControllerChangeHandler,
+          changeType: ControllerChangeType
+        ) {
+          pauseOnChangeStart(
+            targetController = parent,
+            changeController = controller,
+            changeHandler = changeHandler,
+            changeType = changeType,
+          )
+        }
+      }
+
+      parent.addLifecycleListener(changeListener)
+      parentChangeListeners[controller.instanceId] = changeListener
+
+      listenForParentChangeStart(parent)
+    }
+  }
+
+  private fun stopListeningForParentChangeStart(controller: Controller) {
+    controller.parentController?.let { parent ->
+      parentChangeListeners.remove(parent.instanceId)?.let { listener ->
+        parent.removeLifecycleListener(listener)
+      }
+    }
+  }
+
+  // AbstractComposeView adds its own OnAttachStateChangeListener by default. Since it
+  // does this on init, its detach callbacks get called before ours, which prevents us
+  // from saving state in onDetach. The if statement in here should detect upcoming
+  // detachment.
+  private fun pauseOnChangeStart(
+    targetController: Controller,
+    changeController: Controller,
+    changeHandler: ControllerChangeHandler,
+    changeType: ControllerChangeType,
+  ) {
+    if (
+      targetController === changeController &&
+      !changeType.isEnter &&
+      changeHandler.removesFromViewOnPush() &&
+      changeController.view != null &&
+      lifecycleRegistry.currentState == Lifecycle.State.RESUMED
+    ) {
+      lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+
+      savedRegistryState = Bundle()
+      savedStateRegistryController.performSave(savedRegistryState)
+
+      hasSavedState = true
+    }
+  }
 
   companion object {
     private const val KEY_SAVED_STATE = "Registry.savedState"

--- a/conductor/src/main/java/com/bluelinelabs/conductor/internal/OwnViewTreeLifecycleAndRegistry.kt
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/internal/OwnViewTreeLifecycleAndRegistry.kt
@@ -213,8 +213,8 @@ internal class OwnViewTreeLifecycleAndRegistry private constructor(
   companion object {
     private const val KEY_SAVED_STATE = "Registry.savedState"
 
-    fun own(target: Controller) {
-      OwnViewTreeLifecycleAndRegistry(target)
+    fun own(target: Controller): OwnViewTreeLifecycleAndRegistry {
+      return OwnViewTreeLifecycleAndRegistry(target)
     }
   }
 }

--- a/conductor/src/test/java/com/bluelinelabs/conductor/internal/OwnViewTreeLifecycleAndRegistryTest.kt
+++ b/conductor/src/test/java/com/bluelinelabs/conductor/internal/OwnViewTreeLifecycleAndRegistryTest.kt
@@ -1,0 +1,190 @@
+package com.bluelinelabs.conductor.internal
+
+import android.content.Context
+import android.os.Looper
+import android.view.View
+import androidx.lifecycle.Lifecycle
+import com.bluelinelabs.conductor.Controller
+import com.bluelinelabs.conductor.ControllerChangeHandler
+import com.bluelinelabs.conductor.ControllerChangeType
+import com.bluelinelabs.conductor.TestController
+import com.bluelinelabs.conductor.asTransaction
+import com.bluelinelabs.conductor.util.TestActivity
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class OwnViewTreeLifecycleAndRegistryTest {
+
+  private val router = Robolectric.buildActivity(TestActivity::class.java)
+    .setup()
+    .get()
+    .router
+
+  @Test
+  fun `onCreate lifecycle event before create view`() {
+    assertControllerState(
+      preCreateViewAssertedState = Lifecycle.State.CREATED,
+      setup = { router.setRoot(it.asTransaction()) }
+    )
+  }
+
+  @Test
+  fun `onStart lifecycle event after create view`() {
+    assertControllerState(
+      postCreateViewAssertedState = Lifecycle.State.STARTED,
+      setup = { router.setRoot(it.asTransaction()) }
+    )
+  }
+
+  @Test
+  fun `onResume lifecycle event on attach`() {
+    assertControllerState(
+      postAttachAssertedState = Lifecycle.State.RESUMED,
+      setup = { router.setRoot(it.asTransaction()) }
+    )
+  }
+
+  @Test
+  fun `onPause lifecycle event on exit change start`() {
+    assertControllerState(
+      onChangeStartAssertedState = Lifecycle.State.STARTED,
+      setup = {
+        router.setRoot(it.asTransaction())
+        router.pushController(TestController().asTransaction())
+      }
+    )
+  }
+
+  @Test
+  fun `onPause lifecycle event on parent exit change start`() {
+    val parent = TestController()
+    val controller = TestController()
+    var hasAsserted = false
+    val ownViewTreeLifecycleAndRegistry = OwnViewTreeLifecycleAndRegistry.own(controller)
+
+    // Ensure our listener gets added after OwnViewTreeLifecycleAndRegistry's by waiting until
+    // postContextAvailable to add the lifecycle listener on the parent controller
+    controller.addLifecycleListener(object : Controller.LifecycleListener() {
+      override fun postContextAvailable(controller: Controller, context: Context) {
+        parent.addLifecycleListener(object : Controller.LifecycleListener() {
+          override fun onChangeStart(
+            controller: Controller,
+            changeHandler: ControllerChangeHandler,
+            changeType: ControllerChangeType
+          ) {
+            Assert.assertEquals(Lifecycle.State.STARTED, ownViewTreeLifecycleAndRegistry.lifecycle.currentState)
+            hasAsserted = true
+          }
+        })
+      }
+    })
+
+    router.setRoot(parent.asTransaction())
+    parent.getChildRouter(parent.view!!.findViewById(TestController.VIEW_ID)).setRoot(controller.asTransaction())
+    router.pushController(TestController().asTransaction())
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+    Assert.assertTrue(hasAsserted)
+  }
+
+  @Test
+  fun `onStop lifecycle event on detach`() {
+    assertControllerState(
+      preDetachAssertedState = Lifecycle.State.CREATED,
+      setup = {
+        router.setRoot(it.asTransaction())
+        router.pushController(TestController().asTransaction())
+      }
+    )
+  }
+
+  @Test
+  fun `onDestroy lifecycle event on destroy view`() {
+    assertControllerState(
+      preDestroyViewAssertedState = Lifecycle.State.DESTROYED,
+      setup = {
+        router.setRoot(it.asTransaction())
+        router.pushController(TestController().asTransaction())
+      }
+    )
+  }
+
+  private fun assertControllerState(
+    preCreateViewAssertedState: Lifecycle.State? = null,
+    postCreateViewAssertedState: Lifecycle.State? = null,
+    postAttachAssertedState: Lifecycle.State? = null,
+    preDetachAssertedState: Lifecycle.State? = null,
+    preDestroyViewAssertedState: Lifecycle.State? = null,
+    onChangeStartAssertedState: Lifecycle.State? = null,
+    setup: (Controller) -> Unit = { },
+  ) {
+    val controller = TestController()
+    val ownViewTreeLifecycleAndRegistry = OwnViewTreeLifecycleAndRegistry.own(controller)
+    var hasAsserted = false
+
+    val assertState: (Lifecycle.State) -> Unit = {
+      Assert.assertEquals(it, ownViewTreeLifecycleAndRegistry.lifecycle.currentState)
+    }
+
+    controller.addLifecycleListener(object : Controller.LifecycleListener() {
+      override fun preCreateView(controller: Controller) {
+        preCreateViewAssertedState?.let {
+          assertState(it)
+          hasAsserted = true
+        }
+      }
+
+      override fun postCreateView(controller: Controller, view: View) {
+        postCreateViewAssertedState?.let {
+          assertState(it)
+          hasAsserted = true
+        }
+      }
+
+      override fun postAttach(controller: Controller, view: View) {
+        postAttachAssertedState?.let {
+          assertState(it)
+          hasAsserted = true
+        }
+      }
+
+      override fun preDetach(controller: Controller, view: View) {
+        preDetachAssertedState?.let {
+          assertState(it)
+          hasAsserted = true
+        }
+      }
+
+      override fun preDestroyView(controller: Controller, view: View) {
+        preDestroyViewAssertedState?.let {
+          assertState(it)
+          hasAsserted = true
+        }
+      }
+
+      override fun onChangeStart(
+        controller: Controller,
+        changeHandler: ControllerChangeHandler,
+        changeType: ControllerChangeType
+      ) {
+        if (!changeType.isEnter) {
+          onChangeStartAssertedState?.let {
+            assertState(it)
+            hasAsserted = true
+          }
+        }
+      }
+    })
+
+    setup(controller)
+    Shadows.shadowOf(Looper.getMainLooper()).idle()
+    Assert.assertTrue(hasAsserted)
+  }
+}


### PR DESCRIPTION
Was breaking compose's expected lifecycle events for certain backstack setups.