### PR TITLE
Fix Demo Shared Element can't back press problem

### DIFF
--- a/demo/src/main/java/com/bluelinelabs/conductor/demo/controllers/CityGridController.kt
+++ b/demo/src/main/java/com/bluelinelabs/conductor/demo/controllers/CityGridController.kt
@@ -104,7 +104,7 @@ private class CityGridAdapter(
       binding.title.text = item.title
 
       binding.image.transitionName = itemView.resources.getString(R.string.transition_tag_image_named, item.title)
-      binding.image.transitionName = itemView.resources.getString(R.string.transition_tag_title_named, item.title)
+      binding.title.transitionName = itemView.resources.getString(R.string.transition_tag_title_named, item.title)
 
       itemView.setOnClickListener { modelClickListener(item) }
     }


### PR DESCRIPTION
Cloned the code and run the demo app. Found that if user get into Shared Element Demos and click a photo, they can't go back. Because the transitionName is wrong.