### PR TITLE
Fix NPE when removing view reference

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Controller.java
@@ -1082,7 +1082,7 @@ public abstract class Controller {
     final View inflate(@NonNull ViewGroup parent) {
         if (view != null && view.getParent() != null && view.getParent() != parent) {
             detach(view, true, false);
-            removeViewReference(view.getContext());
+            removeViewReference(view != null ? view.getContext() : null);
         }
 
         if (view == null) {


### PR DESCRIPTION
After upgrading from `3.1.5` to `3.1.6`, we can see users running into a NPE, introduced [here](https://github.com/bluelinelabs/Conductor/compare/3.1.5...3.1.6#diff-45f17ca3409e4f5b7bde2067f79f99c7fff0345979fbb8d2aece39a7c2cdddb2R1085).