### PR TITLE
Fix lifecycle crashes when android-lifecycle is updated to 2.9.0+

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/internal/ControllerLifecycleOwner.kt
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/internal/ControllerLifecycleOwner.kt
@@ -18,23 +18,33 @@ class ControllerLifecycleOwner(lifecycleController: Controller) : LifecycleOwner
     lifecycleController.addLifecycleListener(
       object : LifecycleListener() {
         override fun postContextAvailable(controller: Controller, context: Context) {
-          lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE) // --> State.CREATED;
+          if (lifecycleRegistry.currentState != Lifecycle.State.DESTROYED) {
+            lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE) // --> State.CREATED;
+          }
         }
 
         override fun postCreateView(controller: Controller, view: View) {
-          lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START) // --> State.STARTED;
+          if (lifecycleRegistry.currentState != Lifecycle.State.DESTROYED) {
+            lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START) // --> State.STARTED;
+          }
         }
 
         override fun postAttach(controller: Controller, view: View) {
-          lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME) // --> State.RESUMED;
+          if (lifecycleRegistry.currentState != Lifecycle.State.DESTROYED) {
+            lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME) // --> State.RESUMED;
+          }
         }
 
         override fun preDetach(controller: Controller, view: View) {
-          lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE) // --> State.STARTED;
+          if (lifecycleRegistry.currentState != Lifecycle.State.DESTROYED) {
+            lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE) // --> State.STARTED;
+          }
         }
 
         override fun preDestroyView(controller: Controller, view: View) {
-          lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP) // --> State.CREATED;
+          if (lifecycleRegistry.currentState != Lifecycle.State.DESTROYED) {
+            lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP) // --> State.CREATED;
+          }
         }
 
         override fun preContextUnavailable(controller: Controller, context: Context) {


### PR DESCRIPTION
We recently updated to Compose 1.10.0 and it uses Lifcycle 2.94. [Lifecycle 2.9.0+](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.9.0) has added checks to prevent moving from a lifecycle state of DESTROYED to any other state and throws an error if it happens. Previously it didn't have these checks so it didn't error out. We are blocked from updating lifecycle until we can handle these crashes. 
Example stack trace:
````
Fatal Exception: java.lang.IllegalStateException
State is 'DESTROYED' and cannot be moved to 'STARTED' in component com.bluelinelabs.conductor.internal.c@5750cc3
androidx.lifecycle.LifecycleRegistryKt.checkLifecycleStateTransition (LifecycleRegistry.kt:96)

androidx.lifecycle.LifecycleRegistry.handleLifecycleEvent (LifecycleRegistry.jvm.kt:119)
com.bluelinelabs.conductor.internal.ControllerLifecycleOwner$1.postCreateView (ControllerLifecycleOwner.kt:25)
com.bluelinelabs.conductor.Controller.inflate (Controller.java:1121)
com.bluelinelabs.conductor.ControllerChangeHandler$Companion.executeChange (ControllerChangeHandler.java:265)
com.bluelinelabs.conductor.ControllerChangeHandler$Companion.executeChange (ControllerChangeHandler.java:218)
com.bluelinelabs.conductor.ControllerChangeHandler.executeChange (ControllerChangeHandler.kt:273)
com.bluelinelabs.conductor.Router.performPendingControllerChanges (Router.java:956)
com.bluelinelabs.conductor.Router$2.run (Router.java:812)
android.os.Handler.handleCallback (Handler.java:942)
````